### PR TITLE
Add success toast to bottom-left share button

### DIFF
--- a/components/ShareLinkButton.tsx
+++ b/components/ShareLinkButton.tsx
@@ -20,6 +20,7 @@ export default function ShareLinkButton() {
       // Copy to clipboard
       if (navigator.clipboard && navigator.clipboard.writeText) {
         await navigator.clipboard.writeText(url);
+        toast.success('Link copied to clipboard!');
       } else {
         // Fallback for older browsers
         const textArea = document.createElement('textarea');
@@ -31,6 +32,7 @@ export default function ShareLinkButton() {
         textArea.select();
         try {
           document.execCommand('copy');
+          toast.success('Link copied to clipboard!');
         } catch (err) {
           console.error('Failed to copy link');
         }


### PR DESCRIPTION
The ShareLinkButton (fixed bottom-left corner) silently copied the link
without any user feedback. Added toast.success() for both the modern
clipboard API path and the legacy fallback to match other share buttons.

https://claude.ai/code/session_019icJNt1vuGrQU4NVvW3Gfd