### PR TITLE
Add missing BoostBox GUID params to BoostButton callsites

### DIFF
--- a/components/BaseMusicTrackCard.tsx
+++ b/components/BaseMusicTrackCard.tsx
@@ -370,6 +370,9 @@ function BaseMusicTrackCard({
                   feedId={track.feedUrl}
                   trackTitle={track.title}
                   artistName={track.artist}
+                  remoteFeedGuid={track.valueForValue?.feedGuid}
+                  episodeGuid={track.valueForValue?.itemGuid}
+                  albumName={track.episodeTitle}
                   className="text-sm"
                 />
               </div>

--- a/components/MusicTrackDetail.tsx
+++ b/components/MusicTrackDetail.tsx
@@ -296,6 +296,10 @@ export default function MusicTrackDetail({
                 feedId={track.feedUrl}
                 trackTitle={track.title}
                 artistName={track.artist}
+                remoteFeedGuid={track.valueForValue?.feedGuid}
+                episodeGuid={track.valueForValue?.itemGuid}
+                lightningAddress={track.valueForValue?.lightningAddress}
+                albumName={track.episodeTitle}
                 className="w-full"
               />
             </div>


### PR DESCRIPTION
BaseMusicTrackCard and MusicTrackDetail were not passing
remoteFeedGuid, episodeGuid, or albumName to BoostButton,
causing feed_guid and item_guid to be missing from BoostBox
metadata on LNURL payments. MusicTrackDetail also now passes
lightningAddress from valueForValue data.

https://claude.ai/code/session_011S3BFEaC9oaErzjGEay8bJ