### PR TITLE
fix: prevent NIP-46 boost signing race condition and silent relay failures

### DIFF
--- a/lib/nostr/nip46-client.ts
+++ b/lib/nostr/nip46-client.ts
@@ -3826,8 +3826,13 @@ export class NIP46Client {
         await this.startRelayConnection(relayUrl);
       }
     } catch (err) {
-      console.warn('⚠️ NIP-46: Error checking relay health:', err);
-      // Don't throw — let the sign request proceed anyway
+      // CRITICAL: Propagate relay reconnection errors instead of swallowing them.
+      // If the relay is dead and reconnection fails, signing will hang for 120s
+      // waiting for a response that never comes (causing the app to appear frozen).
+      // Better to fail fast with a clear error so the user sees it immediately.
+      const errorMsg = err instanceof Error ? err.message : String(err);
+      console.error('❌ NIP-46: Relay reconnection failed in ensureSubscription:', errorMsg);
+      throw new Error(`Relay connection lost and reconnection failed: ${errorMsg}. Please try again.`);
     }
   }
 

--- a/lib/nostr/signer-reconnect.ts
+++ b/lib/nostr/signer-reconnect.ts
@@ -296,7 +296,13 @@ export async function ensureSignerAvailable(): Promise<ReconnectResult> {
   const signer = getUnifiedSigner();
   const loginType = getLoginType();
 
-  // Try to reinitialize first
+  // CRITICAL: Wait for the constructor's async initialization to complete first.
+  // Without this, isAvailable() returns false while init is still in flight,
+  // triggering a redundant reinitialize() that races with the original init —
+  // creating two NIP-46 clients competing for the same relay connection.
+  await signer.ensureInitialized();
+
+  // Try to reinitialize if still not available after init completed
   if (!signer.isAvailable()) {
     try {
       await signer.reinitialize();

--- a/lib/nostr/signer.ts
+++ b/lib/nostr/signer.ts
@@ -398,9 +398,11 @@ export class UnifiedSigner {
 
   /**
    * Reinitialize signer (useful after connection changes)
+   * Updates initPromise so ensureInitialized() callers see the new result
    */
   async reinitialize(): Promise<void> {
-    await this.initialize();
+    this.initPromise = this.initialize();
+    await this.initPromise;
   }
 
   /**


### PR DESCRIPTION
Three interconnected bugs caused boost Nostr signing to fail after Primal
login on iOS:

1. ensureSignerAvailable() never awaited the constructor's async init,
   triggering a redundant reinitialize() that raced with the original —
   creating two NIP-46 clients competing for the same relay connection.

2. reinitialize() didn't update initPromise, so ensureInitialized()
   callers still awaited the stale original promise.

3. ensureSubscription() silently swallowed relay reconnection errors,
   letting signEvent() proceed against a dead relay and hang for 120s
   waiting for a response that never comes (appearing as a freeze).

https://claude.ai/code/session_01DqMLmXH1hkEFoe3TXJKX9i