### PR TITLE
fix: clean up NIP-46 state on logout so boost signing works after re-login

### DIFF
--- a/components/Nostr/hooks/useNip46Connection.ts
+++ b/components/Nostr/hooks/useNip46Connection.ts
@@ -124,11 +124,18 @@ export function useNip46Connection(options: UseNip46ConnectionOptions): Nip46Con
         if (currentUserPubkey && storedConnection.pubkey !== currentUserPubkey) {
           throw new Error('Stored connection is for a different user. Please reconnect.');
         }
-        // Create client and restore connection
+        // Create client and restore connection using proper connect() to
+        // establish a real relay WebSocket. The old code injected the stored
+        // connection object directly, which left the client with no relay
+        // link — signing requests would silently fail.
         const client = new NIP46Client();
-
-        // Manually set the connection data from storage
-        (client as any).connection = storedConnection;
+        await client.connect(
+          storedConnection.signerUrl,
+          storedConnection.token,
+          false,
+          storedConnection.pubkey
+        );
+        await client.authenticate();
 
         setNip46Client(client);
         nip46ClientRef.current = client;

--- a/contexts/NostrContext.tsx
+++ b/contexts/NostrContext.tsx
@@ -150,6 +150,22 @@ export function NostrProvider({ children }: { children: React.ReactNode }) {
     clearStoredUserRelays(); // Clear NIP-65 relay list
     setUser(null);
 
+    // Clean up NIP-46 signer and connection state so the next login starts fresh
+    import('@/lib/nostr/signer').then(({ resetUnifiedSigner }) => {
+      resetUnifiedSigner().catch(err => {
+        console.warn('Failed to reset signer on logout:', err);
+      });
+    }).catch(err => {
+      console.warn('Failed to import signer module on logout:', err);
+    });
+
+    // Clear saved NIP-46 connection data from localStorage
+    import('@/lib/nostr/nip46-storage').then(({ clearNIP46Connection }) => {
+      clearNIP46Connection();
+    }).catch(err => {
+      console.warn('Failed to clear NIP-46 connection on logout:', err);
+    });
+
     // Call logout API
     fetch('/api/nostr/auth/logout', {
       method: 'POST',

--- a/lib/nostr/signer.ts
+++ b/lib/nostr/signer.ts
@@ -602,3 +602,19 @@ export function getUnifiedSigner(): UnifiedSigner {
   return unifiedSignerInstance;
 }
 
+/**
+ * Reset the unified signer singleton (call on logout)
+ * Disconnects NIP-46 and clears all signer state so the next
+ * login starts completely fresh.
+ */
+export async function resetUnifiedSigner(): Promise<void> {
+  if (unifiedSignerInstance) {
+    try {
+      await unifiedSignerInstance.disconnectNIP46();
+    } catch {
+      // Ignore disconnect errors during cleanup
+    }
+    unifiedSignerInstance = null;
+  }
+}
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "podcast-music-site",
-  "version": "1.2a31171cee",
+  "version": "1.2a36666bf",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Logout was not cleaning up NIP-46 connection state — the WebSocket stayed
open, the UnifiedSigner singleton kept stale references, and the saved
connection persisted in localStorage. After signing out and back in with
Primal, signing requests could silently fail because the client held dead
relay connections.

Three fixes:
1. Add resetUnifiedSigner() that disconnects NIP-46 and nulls the singleton
2. Call it (plus clearNIP46Connection) from the logout flow
3. Use proper client.connect() in useNip46Connection auto-reconnect instead
   of injecting raw connection metadata — the old (client as any).connection
   bypass left the client with no relay WebSocket

https://claude.ai/code/session_01YJ9B2THyHugr4vaFR51wbZ