### PR TITLE
Remove Nostr signup/key creation from app

### DIFF
--- a/components/Nostr/LoginModal.tsx
+++ b/components/Nostr/LoginModal.tsx
@@ -781,7 +781,7 @@ export default function LoginModal({ onClose }: LoginModalProps) {
             </button>
             <div className="mt-3 p-3 bg-green-50 border border-green-200 rounded-md">
               <p className="text-xs text-green-800">
-                <strong>Works everywhere:</strong> Create a new key, paste your nsec, or connect to a bunker. No app or extension required — keys are managed securely in your browser.
+                <strong>Works everywhere:</strong> Paste your nsec or connect to a bunker. No app or extension required. Need a Nostr account? Create one with an app like <a href="https://primal.net" target="_blank" rel="noopener noreferrer" className="underline">Primal</a> or <a href="https://iris.to" target="_blank" rel="noopener noreferrer" className="underline">Iris</a>.
               </p>
             </div>
           </div>

--- a/components/Nostr/NostrLoginInit.tsx
+++ b/components/Nostr/NostrLoginInit.tsx
@@ -7,12 +7,14 @@ import { useEffect, useRef } from 'react';
  * 
  * This component loads nostr-login which polyfills window.nostr for platforms
  * that don't have browser extensions (iOS, mobile browsers). It supports:
- * - Local key management (keys stored encrypted in browser)
  * - NIP-46 bunker connections
  * - NIP-07 extension detection (defers to existing extensions on desktop)
  * 
  * nostr-login is configured with noBanner so it doesn't show its own UI.
  * Instead, the LoginModal dispatches 'nlLaunch' events to trigger auth flows.
+ *
+ * Note: 'local' method is intentionally excluded — users must create Nostr
+ * keys elsewhere. Only existing key import and bunker connections are supported.
  */
 export default function NostrLoginInit() {
   const initialized = useRef(false);
@@ -28,8 +30,8 @@ export default function NostrLoginInit() {
           noBanner: true,
           // Dark theme to match stablekraft aesthetic
           theme: 'default',
-          // Allow all auth methods: extension, bunker connect, local key
-          methods: ['connect', 'extension', 'local'] as any,
+          // Only allow existing key import and bunker — no local key creation
+          methods: ['connect', 'extension'] as any,
         });
         console.log('✅ nostr-login initialized (iOS/mobile signer support ready)');
       })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "podcast-music-site",
-  "version": "1.2ab737510",
+  "version": "1.2a553e8c8",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Remove the 'local' method from nostr-login initialization so users
can no longer create new Nostr keys within the app. They must create
keys elsewhere (Primal, Iris, etc.) and sign in with an existing
nsec, browser extension, or bunker connection.

https://claude.ai/code/session_018UARjsosRMqBBJB16DTonj