### PR TITLE
fix: correct Two For Tunestr feed ID in nightly workflow; shrink PWA page cache TTL

### DIFF
--- a/.github/workflows/refresh-playlists.yml
+++ b/.github/workflows/refresh-playlists.yml
@@ -61,7 +61,7 @@ jobs:
         echo ""
         echo "📋 Step 2b: Reparsing podcast feeds for new episodes..."
 
-        PODCAST_FEEDS=("3aebb7a8-5942-5ee7-a148-8bdc14f1f3d4" "two-for-tunestr-silvie")  # UpBeats, Two For Tunestr
+        PODCAST_FEEDS=("3aebb7a8-5942-5ee7-a148-8bdc14f1f3d4" "silvie-two-for-tunestr")  # UpBeats, Two For Tunestr
 
         for FEED_ID in "${PODCAST_FEEDS[@]}"; do
           echo "  🔄 Reparsing podcast feed $FEED_ID..."

--- a/next.config.js
+++ b/next.config.js
@@ -104,7 +104,7 @@ const withPWA = require('next-pwa')({
         cacheName: 'pages-cache',
         expiration: {
           maxEntries: 50,
-          maxAgeSeconds: 60 * 60 * 24, // 1 day
+          maxAgeSeconds: 60 * 60, // 1 hour — avoid iOS PWA sitting on stale shells
         },
         networkTimeoutSeconds: 3,
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "podcast-music-site",
-  "version": "1.2a09eb9ab",
+  "version": "1.2a5573737",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
- refresh-playlists.yml referenced `two-for-tunestr-silvie` but the DB
  feed ID is `silvie-two-for-tunestr` (per lib/podcast-feeds.ts), so the
  nightly reparse was hitting /api/admin/feeds/.../reparse with a bad ID
  and silently 404ing. Swap halves so TFT actually gets reparsed nightly.
- Drop pages-cache maxAgeSeconds from 24h to 1h so the iOS PWA stops
  sitting on stale page shells (chapter ticks were missing on mobile
  while desktop rendered fine — service-worker cache, not a data issue).

https://claude.ai/code/session_0121gbND7ovBq4zknqow8vVh