### PR TITLE
fix: prevent iOS Safari scroll-through behind Now Playing screen

### DIFF
--- a/components/Lightning/WalletInfoDisplay.tsx
+++ b/components/Lightning/WalletInfoDisplay.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect, useRef } from 'react';
 import { useBitcoinConnect } from './BitcoinConnectProvider';
-import { Wallet, RefreshCw, Copy, ExternalLink, Check, Plus, X, CheckCircle } from 'lucide-react';
+import { Wallet, RefreshCw, Copy, ExternalLink, Check, Plus, X, CheckCircle, Info } from 'lucide-react';
 import { QRCodeSVG } from 'qrcode.react';
 import {
   formatBalance,
@@ -97,6 +97,18 @@ export function WalletInfoDisplay({
     return null;
   };
   const providerLogo = getProviderLogo();
+
+  // NWC-type connections (Alby Hub, Alby, generic NWC) may be scoped to an
+  // isolated sub-account (balance = sub-account only) or a full-access app
+  // connection (balance = entire node). The displayed balance depends on the
+  // NWC URL used. Show a hint so users aren't confused when they see their
+  // full hub total instead of a sub-account balance.
+  const isNwcLike =
+    walletProviderType === 'alby-hub' ||
+    walletProviderType === 'alby' ||
+    walletProviderType === 'nwc';
+  const balanceHint =
+    'For NWC wallets this shows whatever balance the NWC connection is scoped to. Alby Hub: an isolated sub-wallet\'s NWC URL shows the sub-wallet balance; a hub-wide URL (including AlbyGo\'s automatic pairing) shows your full node balance. To see a single sub-wallet, pair it from inside that sub-wallet\'s screen in AlbyGo, or generate the NWC URL from the Alby Hub web admin.';
 
   const handleCopyAddress = async () => {
     if (walletInfo.lightningAddress) {
@@ -212,7 +224,18 @@ export function WalletInfoDisplay({
         {showBalance && walletInfo.supportsBalance && (
           <div className="bg-gray-800/50 rounded-lg p-3">
             <div className="flex items-center justify-between mb-1">
-              <span className="text-gray-400 text-sm">Balance</span>
+              <div className="flex items-center gap-1.5">
+                <span className="text-gray-400 text-sm">Balance</span>
+                {isNwcLike && (
+                  <span
+                    className="inline-flex cursor-help"
+                    aria-label="Balance info"
+                    title={balanceHint}
+                  >
+                    <Info className="w-3.5 h-3.5 text-gray-500" />
+                  </span>
+                )}
+              </div>
               <button
                 onClick={handleRefreshBalance}
                 disabled={isBalanceLoading}
@@ -421,7 +444,18 @@ export function WalletInfoDisplay({
           <div className="bg-gray-900/50 rounded-lg p-3">
             <div className="flex items-center justify-between">
               <div>
-                <span className="text-gray-400 text-sm block">Balance</span>
+                <div className="flex items-center gap-1.5">
+                  <span className="text-gray-400 text-sm">Balance</span>
+                  {isNwcLike && (
+                    <span
+                      className="inline-flex cursor-help"
+                      aria-label="Balance info"
+                      title={balanceHint}
+                    >
+                      <Info className="w-3.5 h-3.5 text-gray-500" />
+                    </span>
+                  )}
+                </div>
                 <div className="text-2xl font-bold text-yellow-400 font-mono">
                   {balance !== null ? formatBalance(balance) : '---'}
                 </div>

--- a/components/NowPlayingScreen.tsx
+++ b/components/NowPlayingScreen.tsx
@@ -220,6 +220,40 @@ export default function NowPlayingScreen({ isOpen, onClose }: NowPlayingScreenPr
     }
   }, [shouldShow, isVideoMode, videoRef]);
 
+  // Lock body scroll while fullscreen Now Playing is open.
+  // Without this, iOS Safari's elastic bounce reveals the main page behind the
+  // fixed overlay when the user scrolls/drags up inside the screen.
+  useEffect(() => {
+    if (!shouldShow) return;
+
+    const body = document.body;
+    const html = document.documentElement;
+    const scrollY = window.scrollY;
+
+    const prevBodyOverflow = body.style.overflow;
+    const prevBodyPosition = body.style.position;
+    const prevBodyTop = body.style.top;
+    const prevBodyWidth = body.style.width;
+    const prevHtmlOverscroll = html.style.overscrollBehavior;
+
+    // position: fixed on body is the only reliable way to prevent iOS Safari
+    // from scrolling the page behind a fullscreen overlay.
+    body.style.position = 'fixed';
+    body.style.top = `-${scrollY}px`;
+    body.style.width = '100%';
+    body.style.overflow = 'hidden';
+    html.style.overscrollBehavior = 'none';
+
+    return () => {
+      body.style.overflow = prevBodyOverflow;
+      body.style.position = prevBodyPosition;
+      body.style.top = prevBodyTop;
+      body.style.width = prevBodyWidth;
+      html.style.overscrollBehavior = prevHtmlOverscroll;
+      window.scrollTo(0, scrollY);
+    };
+  }, [shouldShow]);
+
   // Debug: Log V4V data availability
   useEffect(() => {
     if (currentTrack) {
@@ -410,7 +444,7 @@ export default function NowPlayingScreen({ isOpen, onClose }: NowPlayingScreenPr
   }
 
   return (
-    <div className="fixed top-0 left-0 right-0 z-50 overflow-hidden" style={{ height: '100dvh', minHeight: '100vh' }}>
+    <div className="fixed inset-0 z-50 overflow-hidden" style={{ height: '100dvh', overscrollBehavior: 'none', WebkitOverflowScrolling: 'auto' }}>
       {/* Solid Color Background - ITDV Style with good contrast */}
       <div
         className="absolute inset-0 transition-all duration-1000 pointer-events-none"

--- a/contexts/AudioContext.tsx
+++ b/contexts/AudioContext.tsx
@@ -3111,7 +3111,9 @@ export const AudioProvider: React.FC<AudioProviderProps> = ({ children, radioMod
   const playNextTrack = useCallback(async () => {
     // Chapter navigation: if we have real chapters and aren't at the last one, skip to next chapter.
     // OP3 boost-marker chapters are skipped over — they're informational and not meant for navigation.
-    if (!chaptersAreBoostMarkers && chapters.length > 0 && currentChapterIndex >= 0 && currentChapterIndex < chapters.length - 1) {
+    // Skipped when shuffle is active — in shuffle, Next should always advance to the next
+    // shuffled track rather than stepping through VTS segments of the current show.
+    if (!isShuffleMode && !chaptersAreBoostMarkers && chapters.length > 0 && currentChapterIndex >= 0 && currentChapterIndex < chapters.length - 1) {
       const nextChapter = chapters[currentChapterIndex + 1];
       console.debug(`📖 Skipping to next chapter: "${nextChapter.title}" at ${nextChapter.startTime}s`);
       seek(nextChapter.startTime);
@@ -3311,7 +3313,9 @@ export const AudioProvider: React.FC<AudioProviderProps> = ({ children, radioMod
   const playPreviousTrack = useCallback(async () => {
     // Chapter navigation: if we have real chapters, go to previous chapter or start of current.
     // OP3 boost-marker chapters are skipped over — prev goes to the previous track instead.
-    if (!chaptersAreBoostMarkers && chapters.length > 0 && currentChapterIndex >= 0) {
+    // Skipped when shuffle is active — in shuffle, Previous should move between shuffled
+    // tracks rather than stepping through VTS segments of the current show.
+    if (!isShuffleMode && !chaptersAreBoostMarkers && chapters.length > 0 && currentChapterIndex >= 0) {
       const currentChapter = chapters[currentChapterIndex];
       const timeIntoChapter = currentTimeRef.current - currentChapter.startTime;
 

--- a/contexts/AudioContext.tsx
+++ b/contexts/AudioContext.tsx
@@ -17,6 +17,21 @@ import { hasV4V as checkHasV4V, getV4VRecipients, getPrimaryRecipient, formatVal
 import { prefetchUpcomingTracks, prefetchAudio } from '@/lib/audio-prefetch';
 import { PodcastChapter } from '@/lib/podcast-types';
 
+/**
+ * Detect OP3 boost chapter feeds. OP3 surfaces each boost as a "chapter" so
+ * listeners can see who boosted and when. These are informational markers —
+ * we render them on the progress bar but never skip between them on next/prev.
+ */
+function isBoostChaptersUrl(url: string | undefined | null): boolean {
+  if (!url) return false;
+  try {
+    const hostname = new URL(url).hostname.toLowerCase();
+    return hostname === 'op3.dev' || hostname.endsWith('.op3.dev');
+  } catch {
+    return /(^|\/\/)op3\.dev\//i.test(url);
+  }
+}
+
 interface AudioContextType {
   // Audio state
   currentPlayingAlbum: RSSAlbum | null;
@@ -110,6 +125,10 @@ export const AudioProvider: React.FC<AudioProviderProps> = ({ children, radioMod
   // Chapter state for podcast navigation
   const [chapters, setChapters] = useState<PodcastChapter[]>([]);
   const [currentChapterIndex, setCurrentChapterIndex] = useState(-1);
+  // OP3 boost chapters are informational markers (each boost is a "chapter").
+  // We still render them on the progress bar, but skip/next should advance to
+  // the next track rather than cycling through individual boost markers.
+  const [chaptersAreBoostMarkers, setChaptersAreBoostMarkers] = useState(false);
   const chaptersTrackKeyRef = useRef<string>(''); // Track which episode chapters belong to
   const currentTimeRef = useRef(0); // Ref for currentTime to avoid re-creating callbacks
 
@@ -3090,15 +3109,16 @@ export const AudioProvider: React.FC<AudioProviderProps> = ({ children, radioMod
 
   // Play next track - moved before useEffect hooks that depend on it
   const playNextTrack = useCallback(async () => {
-    // Chapter navigation: if we have chapters and aren't at the last one, skip to next chapter
-    if (chapters.length > 0 && currentChapterIndex >= 0 && currentChapterIndex < chapters.length - 1) {
+    // Chapter navigation: if we have real chapters and aren't at the last one, skip to next chapter.
+    // OP3 boost-marker chapters are skipped over — they're informational and not meant for navigation.
+    if (!chaptersAreBoostMarkers && chapters.length > 0 && currentChapterIndex >= 0 && currentChapterIndex < chapters.length - 1) {
       const nextChapter = chapters[currentChapterIndex + 1];
       console.debug(`📖 Skipping to next chapter: "${nextChapter.title}" at ${nextChapter.startTime}s`);
       seek(nextChapter.startTime);
       setCurrentChapterIndex(currentChapterIndex + 1);
       return;
     }
-    // If at last chapter (or no chapters), fall through to normal next-track behavior
+    // If at last chapter (or no chapters, or boost markers), fall through to normal next-track behavior
 
     console.log('⏭️ playNextTrack called from lockscreen', {
       repeatMode,
@@ -3280,7 +3300,7 @@ export const AudioProvider: React.FC<AudioProviderProps> = ({ children, radioMod
         setCurrentTrackIndex(0);
       }
     }
-  }, [currentPlayingAlbum, currentTrackIndex, isShuffleMode, shuffledPlaylist, currentShuffleIndex, playShuffledTrack, playAlbum, repeatMode, chapters, currentChapterIndex, seek]);
+  }, [currentPlayingAlbum, currentTrackIndex, isShuffleMode, shuffledPlaylist, currentShuffleIndex, playShuffledTrack, playAlbum, repeatMode, chapters, currentChapterIndex, chaptersAreBoostMarkers, seek]);
 
   // Update the ref whenever playNextTrack changes
   useEffect(() => {
@@ -3289,8 +3309,9 @@ export const AudioProvider: React.FC<AudioProviderProps> = ({ children, radioMod
 
   // Play previous track
   const playPreviousTrack = useCallback(async () => {
-    // Chapter navigation: if we have chapters, go to previous chapter or start of current
-    if (chapters.length > 0 && currentChapterIndex >= 0) {
+    // Chapter navigation: if we have real chapters, go to previous chapter or start of current.
+    // OP3 boost-marker chapters are skipped over — prev goes to the previous track instead.
+    if (!chaptersAreBoostMarkers && chapters.length > 0 && currentChapterIndex >= 0) {
       const currentChapter = chapters[currentChapterIndex];
       const timeIntoChapter = currentTimeRef.current - currentChapter.startTime;
 
@@ -3343,7 +3364,7 @@ export const AudioProvider: React.FC<AudioProviderProps> = ({ children, radioMod
     } else {
       console.log('⚠️ Already at first track');
     }
-  }, [isShuffleMode, shuffledPlaylist, currentShuffleIndex, playShuffledTrack, currentPlayingAlbum, currentTrackIndex, playAlbum, chapters, currentChapterIndex, seek]);
+  }, [isShuffleMode, shuffledPlaylist, currentShuffleIndex, playShuffledTrack, currentPlayingAlbum, currentTrackIndex, playAlbum, chapters, currentChapterIndex, chaptersAreBoostMarkers, seek]);
 
   // Update the ref whenever playPreviousTrack changes
   useEffect(() => {
@@ -3362,11 +3383,14 @@ export const AudioProvider: React.FC<AudioProviderProps> = ({ children, radioMod
     if (trackKey === chaptersTrackKeyRef.current) return;
     chaptersTrackKeyRef.current = trackKey;
 
+    const isBoostChapters = isBoostChaptersUrl(track.chaptersUrl);
+
     // Use pre-loaded chapters from DB if available
     if (track.chapters && Array.isArray(track.chapters) && track.chapters.length > 0) {
       setChapters(track.chapters);
       setCurrentChapterIndex(0);
-      console.debug(`📖 Using ${track.chapters.length} pre-loaded chapters for: ${track.title}`);
+      setChaptersAreBoostMarkers(isBoostChapters);
+      console.debug(`📖 Using ${track.chapters.length} pre-loaded chapters for: ${track.title}${isBoostChapters ? ' (boost markers)' : ''}`);
       return;
     }
 
@@ -3374,6 +3398,7 @@ export const AudioProvider: React.FC<AudioProviderProps> = ({ children, radioMod
     if (!track.chaptersUrl) {
       setChapters([]);
       setCurrentChapterIndex(-1);
+      setChaptersAreBoostMarkers(false);
       return;
     }
 
@@ -3387,10 +3412,12 @@ export const AudioProvider: React.FC<AudioProviderProps> = ({ children, radioMod
         if (data?.chapters?.length > 0) {
           setChapters(data.chapters);
           setCurrentChapterIndex(0);
-          console.debug(`📖 Fetched ${data.chapters.length} chapters for: ${track.title}`);
+          setChaptersAreBoostMarkers(isBoostChapters);
+          console.debug(`📖 Fetched ${data.chapters.length} chapters for: ${track.title}${isBoostChapters ? ' (boost markers)' : ''}`);
         } else {
           setChapters([]);
           setCurrentChapterIndex(-1);
+          setChaptersAreBoostMarkers(false);
         }
       })
       .catch(err => {
@@ -3398,6 +3425,7 @@ export const AudioProvider: React.FC<AudioProviderProps> = ({ children, radioMod
           console.warn('Failed to load chapters:', err);
           setChapters([]);
           setCurrentChapterIndex(-1);
+          setChaptersAreBoostMarkers(false);
         }
       });
 


### PR DESCRIPTION
Lock body scroll with position: fixed when the fullscreen overlay is open,
and anchor the overlay to all four edges instead of relying on minHeight:
100vh (which exceeds the visible viewport in iOS Safari when the URL bar
is showing). This stops the main album grid from peeking through below
the controls when dragging up inside the overlay.

https://claude.ai/code/session_01TKFbMFShQAxmkSn1dwDCmF