### PR TITLE
fix: reflex proxy fallback for client-side chapters fetch

### DIFF
--- a/app/api/chapters/route.ts
+++ b/app/api/chapters/route.ts
@@ -5,6 +5,12 @@ import { parseChaptersJSON } from '@/lib/rss-parser-db';
  * GET /api/chapters?url=<chaptersUrl>
  * Proxies podcast chapter JSON files to avoid CORS issues on the client.
  * Returns parsed and sorted chapters array.
+ *
+ * Reflex fallback: if the URL is a `reflex.livewire.io/chapters/<direct-url>`
+ * proxy path and the proxy fails or returns non-JSON, retry against the direct
+ * URL extracted from the path. Mirrors the server-side `fetchChapters()`
+ * behavior so the client-side loader recovers from the same outage that the
+ * import-time fetch hits.
  */
 export async function GET(request: NextRequest) {
   const url = request.nextUrl.searchParams.get('url');
@@ -13,19 +19,85 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Missing url parameter' }, { status: 400 });
   }
 
-  // URL validation + SSRF protection
+  const primary = validateChaptersUrl(url);
+  if ('error' in primary) {
+    return NextResponse.json({ error: primary.error }, { status: 400 });
+  }
+
+  // Try the primary URL first.
+  let chapters = await fetchAndParse(primary.url);
+
+  // Reflex proxy fallback: format is `.../chapters/https://actual-url.json`.
+  // Only trigger the fallback if the URL is actually a reflex proxy path —
+  // other paths with a /chapters/ segment (e.g. podcast-hosted chapter feeds)
+  // should not get a second hop.
+  if (!chapters && isReflexProxyUrl(primary.url)) {
+    const directMatch = primary.url.match(/\/chapters\/(https?:\/\/.+)$/);
+    if (directMatch) {
+      const fallback = validateChaptersUrl(directMatch[1]);
+      if (!('error' in fallback)) {
+        console.log('🔄 Reflex chapters proxy failed, retrying direct URL');
+        chapters = await fetchAndParse(fallback.url);
+      }
+    }
+  }
+
+  if (!chapters) {
+    // Don't cache failures — next request should re-try the upstream.
+    return NextResponse.json(
+      { error: 'Failed to fetch chapters' },
+      { status: 502, headers: { 'Cache-Control': 'no-store' } }
+    );
+  }
+
+  return NextResponse.json(
+    { chapters },
+    {
+      headers: {
+        'Cache-Control': 'public, max-age=3600, s-maxage=3600',
+      },
+    }
+  );
+}
+
+function isReflexProxyUrl(url: string): boolean {
+  try {
+    const host = new URL(url).hostname.toLowerCase();
+    return host === 'reflex.livewire.io' || host.endsWith('.reflex.livewire.io');
+  } catch {
+    return false;
+  }
+}
+
+async function fetchAndParse(url: string) {
+  try {
+    const response = await fetch(url, {
+      headers: { 'User-Agent': 'StableKraft/1.0' },
+      signal: AbortSignal.timeout(10000),
+    });
+    if (!response.ok) return null;
+    const data = await response.json();
+    return parseChaptersJSON(data);
+  } catch (error) {
+    console.warn(`⚠️ Failed to fetch chapters from ${url}:`, error instanceof Error ? error.message : error);
+    return null;
+  }
+}
+
+// URL validation + SSRF protection. Returns the validated URL string on success
+// or `{ error }` on rejection.
+function validateChaptersUrl(url: string): { url: string } | { error: string } {
   let parsed: URL;
   try {
     parsed = new URL(url);
   } catch {
-    return NextResponse.json({ error: 'Invalid URL' }, { status: 400 });
+    return { error: 'Invalid URL' };
   }
 
   if (parsed.protocol !== 'https:') {
-    return NextResponse.json({ error: 'Only HTTPS URLs are allowed' }, { status: 400 });
+    return { error: 'Only HTTPS URLs are allowed' };
   }
 
-  // Block private/internal hostnames
   const hostname = parsed.hostname.toLowerCase();
   if (
     hostname === 'localhost' ||
@@ -39,42 +111,8 @@ export async function GET(request: NextRequest) {
     /^169\.254\./.test(hostname) ||
     hostname === '0.0.0.0'
   ) {
-    return NextResponse.json({ error: 'Private URLs are not allowed' }, { status: 400 });
+    return { error: 'Private URLs are not allowed' };
   }
 
-  try {
-    const response = await fetch(url, {
-      headers: { 'User-Agent': 'StableKraft/1.0' },
-      signal: AbortSignal.timeout(10000),
-    });
-
-    if (!response.ok) {
-      return NextResponse.json(
-        { error: `Failed to fetch chapters: ${response.status}` },
-        { status: 502 }
-      );
-    }
-
-    const data = await response.json();
-    const chapters = parseChaptersJSON(data);
-
-    if (!chapters) {
-      return NextResponse.json({ error: 'Invalid chapters format' }, { status: 502 });
-    }
-
-    return NextResponse.json(
-      { chapters },
-      {
-        headers: {
-          'Cache-Control': 'public, max-age=3600, s-maxage=3600',
-        },
-      }
-    );
-  } catch (error) {
-    console.error('Error fetching chapters:', error);
-    return NextResponse.json(
-      { error: 'Failed to fetch chapters' },
-      { status: 500 }
-    );
-  }
+  return { url: parsed.toString() };
 }


### PR DESCRIPTION
Chapter tick marks weren't rendering on the Now Playing progress bar
(both desktop and iOS Safari) for episodes whose `chaptersUrl` points at
`reflex.livewire.io`. The server-side `fetchChapters()` in
`lib/rss-parser-db.ts` already extracts the direct URL from the reflex
proxy path on failure, but the client-side `/api/chapters` proxy did
not — so when the track had no pre-loaded chapters in the DB and the
reflex proxy returned 4xx, the client got a 502 and rendered no ticks.

- Mirror the reflex fallback in the API route: on failure, if the URL is
  a `reflex.livewire.io` proxy, extract and re-validate the embedded
  direct URL and retry once.
- Factor validation into a `validateChaptersUrl` helper so the fallback
  URL also goes through SSRF checks.
- Add `Cache-Control: no-store` to error responses so Safari doesn't
  sit on a cached 502 across reloads.