### PR TITLE
fix: replace recursive debugLog with console.log

### DIFF
--- a/lib/nostr/nip46-client.ts
+++ b/lib/nostr/nip46-client.ts
@@ -97,7 +97,7 @@ export class NIP46Client {
   // Enable with: localStorage.setItem('nip46_debug', 'true')
   private static DEBUG = typeof window !== 'undefined' && localStorage.getItem('nip46_debug') === 'true';
   private debugLog(...args: any[]) {
-    if (NIP46Client.DEBUG) this.debugLog(...args);
+    if (NIP46Client.DEBUG) console.log(...args);
   }
 
   // iOS Safari kills WebSocket connections after ~30 seconds when backgrounded

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "podcast-music-site",
-  "version": "1.2a2cff568",
+  "version": "1.2abf88df8",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
NIP46Client.debugLog was calling itself: `if (DEBUG) this.debugLog(...)`.
With the debug flag ON (the documented way to diagnose NIP-46 problems,
`localStorage.setItem('nip46_debug', 'true')`), every debug call blew the
stack and the async connect flow never settled — matching the "Waiting on
signer" toast timing out on iOS PWA with Aegis. With the flag OFF it was
a silent no-op, which also explained why no diagnostic logs ever showed
up in the console during troubleshooting.

Swap the self-call for console.log so debug mode actually prints and the
connect flow doesn't stack-overflow.

https://claude.ai/code/session_01H6GyEq7fo2RB5sx5mouhyQ