### PR TITLE
Fix NIP-46 relay reconnection for Primal boost signing

### DIFF
--- a/lib/nostr/nip46-client.ts
+++ b/lib/nostr/nip46-client.ts
@@ -3619,18 +3619,48 @@ export class NIP46Client {
           }
         }
         
-        // Now ensure relay is connected
+        // Now ensure relay is connected — check actual WebSocket state, not just
+        // the relayClient object.  iOS Safari kills WebSockets when the PWA is
+        // backgrounded; the relayClient object survives but its socket is CLOSED.
+        // In that case we must call startRelayConnection() to create a fresh socket.
         if (this.relayClient) {
-          const connectedRelays = this.relayClient.getConnectedRelays?.() || [];
-          if (connectedRelays.length === 0) {
-            this.debugLog('⏳ NIP-46: Relay not connected yet, waiting briefly...');
-            // Wait up to 3 seconds for relay to connect
-            for (let i = 0; i < 30; i++) {
+          let relayAlive = false;
+
+          // Primary check: ask the relay manager for real WebSocket readyState
+          try {
+            const relayManager = (this.relayClient as any).relayManager;
+            relayAlive = relayManager?.isConnected?.(relayUrl) === true;
+          } catch {
+            // Fall back to the connected-relays list
+            const connectedRelays = this.relayClient.getConnectedRelays?.() || [];
+            relayAlive = connectedRelays.length > 0;
+          }
+
+          if (!relayAlive) {
+            this.debugLog('⏳ NIP-46: Relay not connected, waiting briefly before forcing reconnect...');
+            // Give the existing socket a short chance (e.g. reconnect in progress)
+            for (let i = 0; i < 15; i++) {
               await new Promise(resolve => setTimeout(resolve, 100));
-              const retryRelays = this.relayClient.getConnectedRelays?.() || [];
-              if (retryRelays.length > 0) {
-                this.debugLog('✅ NIP-46: Relay connected');
-                break;
+              try {
+                const rm = (this.relayClient as any).relayManager;
+                if (rm?.isConnected?.(relayUrl) === true) {
+                  relayAlive = true;
+                  this.debugLog('✅ NIP-46: Relay reconnected on its own');
+                  break;
+                }
+              } catch { /* ignore */ }
+            }
+
+            // If still dead after 1.5 s, force a fresh relay connection
+            if (!relayAlive) {
+              this.debugLog('⚠️ NIP-46: Relay WebSocket is dead, forcing reconnection...');
+              try {
+                await this.startRelayConnection(relayUrl);
+                this.debugLog('✅ NIP-46: Relay reconnected via startRelayConnection');
+              } catch (reconnectErr) {
+                console.warn('⚠️ NIP-46: Failed to force-reconnect relay in authenticate():', reconnectErr);
+                // Don't throw — let the caller decide what to do when
+                // isConnected() returns false after we set connected=true below.
               }
             }
           }

--- a/lib/nostr/signer-reconnect.ts
+++ b/lib/nostr/signer-reconnect.ts
@@ -254,15 +254,30 @@ export async function verifyNIP46Connection(
   });
 
   // If connection object exists but relay is stale (e.g. iOS killed WebSocket),
-  // attempt to re-authenticate before giving up
+  // attempt to re-authenticate.  authenticate() now detects dead relay WebSockets
+  // and forces reconnection via startRelayConnection().
   if (!isConnected && connection) {
-    console.log('🔄 NIP-46: Connection stale, attempting re-authentication...');
+    console.log('🔄 NIP-46: Connection stale, attempting re-authentication (with relay reconnect)...');
     try {
       await nip46Client.authenticate();
       isConnected = nip46Client.isConnected();
       console.log('🔄 NIP-46: Re-authentication result:', { isConnected });
     } catch (err) {
       console.warn('⚠️ NIP-46: Re-authentication failed:', err);
+    }
+
+    // If still not connected, give the relay a moment — the fresh WebSocket may
+    // still be completing the handshake after startRelayConnection returned.
+    if (!isConnected) {
+      console.log('🔄 NIP-46: Still not connected, waiting briefly for relay handshake...');
+      for (let i = 0; i < 10; i++) {
+        await new Promise(resolve => setTimeout(resolve, 200));
+        if (nip46Client.isConnected()) {
+          isConnected = true;
+          console.log('✅ NIP-46: Relay connected after brief wait');
+          break;
+        }
+      }
     }
   }
 

--- a/lib/nostr/signer.ts
+++ b/lib/nostr/signer.ts
@@ -282,15 +282,23 @@ export class UnifiedSigner {
         } catch (error) {
           const errorMessage = error instanceof Error ? error.message : String(error);
           console.warn('⚠️ UnifiedSigner: Failed to restore NIP-46/nsecBunker connection:', error);
-          
-          // Check if the error is due to p-tag mismatch (old connection)
-          if (errorMessage.includes('Signer public key not available') || 
-              errorMessage.includes('different app pubkey') ||
-              errorMessage.includes('p tag')) {
-            console.warn('⚠️ UnifiedSigner: Detected stale NIP-46/nsecBunker connection. Connection has been cleared. Please reconnect with a fresh QR code.');
+
+          // Only clear the saved connection for authentication / pubkey mismatch
+          // errors (stale connection that can never work again).  Do NOT clear for
+          // temporary relay errors — the saved credentials are still valid and the
+          // next ensureSignerAvailable() / restoreNIP46Connection() call can retry.
+          const isStaleConnectionError =
+            errorMessage.includes('Signer public key not available') ||
+            errorMessage.includes('different app pubkey') ||
+            errorMessage.includes('p tag');
+
+          if (isStaleConnectionError) {
+            console.warn('⚠️ UnifiedSigner: Detected stale NIP-46/nsecBunker connection. Clearing saved connection. Please reconnect with a fresh QR code.');
+            clearNIP46Connection();
+          } else {
+            console.warn('⚠️ UnifiedSigner: Relay connection error (not clearing saved connection — credentials still valid for retry)');
           }
-          
-          clearNIP46Connection();
+
           // Don't fall through - user chose NIP-46/nsecBunker, so don't try NIP-07
           return;
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "podcast-music-site",
-  "version": "1.2a805b8a9",
+  "version": "1.2ae932a68",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
When iOS Safari backgrounds the PWA, it kills WebSocket connections.
The NIP-46 relay client object survives but its socket is CLOSED.
Previously, authenticate() detected 0 connected relays but only waited
3s hoping they'd reconnect — dead sockets never auto-reconnect.

Three fixes:

1. authenticate() (nip46-client.ts): Check actual WebSocket state via
   relayManager.isConnected(), and if dead, force a fresh connection
   via startRelayConnection() instead of just waiting.

2. initialize() (signer.ts): Only clear saved NIP-46 connection from
   localStorage for stale auth/pubkey errors, not temporary relay
   failures. Preserves credentials so restoreNIP46Connection() can
   retry.

3. verifyNIP46Connection() (signer-reconnect.ts): After calling
   authenticate() (which now reconnects dead relays), add a brief
   polling wait for the relay handshake to complete before giving up.

https://claude.ai/code/session_013iq1GEK5F9LGz2U8bWSSYt