### PR TITLE
feat(filters): add Genre + V4V Music Tag filters with ingest pipeline

### DIFF
--- a/.github/workflows/refresh-playlists.yml
+++ b/.github/workflows/refresh-playlists.yml
@@ -206,8 +206,28 @@ jobs:
         echo ""
         echo "✅ All playlists updated with newly parsed tracks"
 
+        # Step 7: Ingest crowd-sourced v4vmusic.com tags into local Tag/TrackTag tables.
+        # Non-fatal: v4vmusic outages shouldn't break the playlist refresh.
+        echo ""
+        echo "📋 Step 7: Ingesting v4vmusic.com tags..."
+        TAGS_HEADERS=()
+        if [ -n "${CRON_SECRET}" ]; then
+          TAGS_HEADERS=(-H "Authorization: Bearer ${CRON_SECRET}")
+        fi
+        TAGS_RESPONSE=$(curl -s -w "\n%{http_code}" --max-time 300 "${TAGS_HEADERS[@]}" "${BASE_URL}/api/cron/ingest-v4v-tags")
+        TAGS_HTTP_CODE=$(echo "$TAGS_RESPONSE" | tail -n1)
+        TAGS_BODY=$(echo "$TAGS_RESPONSE" | sed '$d')
+        if [ "$TAGS_HTTP_CODE" -eq 200 ]; then
+          echo "  ✓ v4v tag ingest completed"
+          echo "$TAGS_BODY" | jq '.' || echo "$TAGS_BODY"
+        else
+          echo "  ⚠️ v4v tag ingest returned HTTP $TAGS_HTTP_CODE (non-critical)"
+          echo "$TAGS_BODY"
+        fi
+
         echo ""
         echo "✨ Playlist refresh workflow completed"
       env:
         BASE_URL: ${{ secrets.PLAYLIST_BASE_URL || 'https://stablekraft.app' }}
+        CRON_SECRET: ${{ secrets.CRON_SECRET }}
 

--- a/app/album/[id]/AlbumDetailClient.tsx
+++ b/app/album/[id]/AlbumDetailClient.tsx
@@ -930,6 +930,28 @@ export default function AlbumDetailClient({ albumTitle, albumId, initialAlbum, e
               {album.explicit && <span className="bg-red-600 text-white px-2 py-1 rounded text-xs">EXPLICIT</span>}
             </div>
 
+            {/* V4V Music tags — union across all tracks (read-only chips, link to grid filter) */}
+            {(() => {
+              const tagSet = new Set<string>();
+              (album.tracks || []).forEach((t: any) => (t.tags || []).forEach((name: string) => tagSet.add(name)));
+              const tags = Array.from(tagSet).sort();
+              if (tags.length === 0) return null;
+              return (
+                <div className="flex flex-wrap items-center justify-center lg:justify-start gap-2 pt-1">
+                  {tags.map(name => (
+                    <Link
+                      key={name}
+                      href={`/?tag=${encodeURIComponent(name)}`}
+                      className="px-2.5 py-0.5 text-xs rounded-full bg-white/5 border border-white/10 text-white/80 hover:bg-white/10 hover:text-white transition-colors"
+                      title={`Browse ${name}`}
+                    >
+                      #{name}
+                    </Link>
+                  ))}
+                </div>
+              );
+            })()}
+
             {/* Share Button */}
             <div className="flex items-center justify-center lg:justify-start">
               <ShareButton

--- a/app/api/admin/cleanup-feeds/route.ts
+++ b/app/api/admin/cleanup-feeds/route.ts
@@ -1,0 +1,174 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+
+// Cutoff date - feeds created before this are considered "manually added" and kept
+const BULK_IMPORT_CUTOFF = new Date('2025-11-01T00:00:00Z');
+
+async function getCleanupStats() {
+  // Get feeds to KEEP
+  const feedsWithTracks = await prisma.feed.findMany({
+    where: { Track: { some: {} } },
+    select: { id: true, title: true }
+  });
+
+  const feedsLinkedToPublisher = await prisma.feed.findMany({
+    where: {
+      publisherId: { not: null },
+      id: { notIn: feedsWithTracks.map(f => f.id) }
+    },
+    select: { id: true, title: true }
+  });
+
+  const publisherFeeds = await prisma.feed.findMany({
+    where: {
+      type: 'publisher',
+      id: { notIn: [...feedsWithTracks, ...feedsLinkedToPublisher].map(f => f.id) }
+    },
+    select: { id: true, title: true }
+  });
+
+  const preImportFeeds = await prisma.feed.findMany({
+    where: {
+      createdAt: { lt: BULK_IMPORT_CUTOFF },
+      id: { notIn: [...feedsWithTracks, ...feedsLinkedToPublisher, ...publisherFeeds].map(f => f.id) }
+    },
+    select: { id: true, title: true }
+  });
+
+  // Combine all IDs to keep
+  const keepIds = new Set([
+    ...feedsWithTracks.map(f => f.id),
+    ...feedsLinkedToPublisher.map(f => f.id),
+    ...publisherFeeds.map(f => f.id),
+    ...preImportFeeds.map(f => f.id)
+  ]);
+
+  // Get feeds to DELETE (only Wavlake feeds not in keep list)
+  const feedsToDelete = await prisma.feed.findMany({
+    where: {
+      id: { notIn: Array.from(keepIds) },
+      originalUrl: { contains: 'wavlake.com' }
+    },
+    select: { id: true, title: true, artist: true, createdAt: true },
+    orderBy: { createdAt: 'desc' }
+  });
+
+  // Get total counts
+  const totalFeeds = await prisma.feed.count();
+  const totalWavlakeFeeds = await prisma.feed.count({
+    where: { originalUrl: { contains: 'wavlake.com' } }
+  });
+
+  return {
+    totalFeeds,
+    totalWavlakeFeeds,
+    keepReasons: {
+      hasTracks: feedsWithTracks.length,
+      linkedToPublisher: feedsLinkedToPublisher.length,
+      isPublisher: publisherFeeds.length,
+      preImport: preImportFeeds.length,
+      totalToKeep: keepIds.size
+    },
+    toDelete: {
+      count: feedsToDelete.length,
+      feeds: feedsToDelete
+    }
+  };
+}
+
+// GET - Preview what will be deleted (dry run)
+export async function GET() {
+  try {
+    console.log('🔍 Running cleanup dry run...');
+
+    const stats = await getCleanupStats();
+
+    return NextResponse.json({
+      dryRun: true,
+      message: 'This is a preview. Use POST with { "confirm": true } to execute.',
+      stats: {
+        totalFeeds: stats.totalFeeds,
+        totalWavlakeFeeds: stats.totalWavlakeFeeds,
+        feedsToKeep: stats.keepReasons.totalToKeep,
+        feedsToDelete: stats.toDelete.count,
+        keepReasons: stats.keepReasons
+      },
+      sampleDeletions: stats.toDelete.feeds.slice(0, 20).map(f => ({
+        id: f.id,
+        title: f.title,
+        artist: f.artist,
+        createdAt: f.createdAt
+      })),
+      allDeletions: stats.toDelete.feeds.map(f => `${f.title} - ${f.artist}`)
+    });
+
+  } catch (error) {
+    console.error('❌ Cleanup dry run error:', error);
+    return NextResponse.json(
+      { error: 'Failed to run cleanup preview', details: error instanceof Error ? error.message : 'Unknown' },
+      { status: 500 }
+    );
+  }
+}
+
+// POST - Execute deletion with confirmation
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+
+    if (!body.confirm) {
+      return NextResponse.json(
+        { error: 'Confirmation required. Send { "confirm": true } to execute cleanup.' },
+        { status: 400 }
+      );
+    }
+
+    console.log('🧹 Starting feed cleanup...');
+
+    const stats = await getCleanupStats();
+    const feedIdsToDelete = stats.toDelete.feeds.map(f => f.id);
+
+    if (feedIdsToDelete.length === 0) {
+      return NextResponse.json({
+        success: true,
+        message: 'No feeds to delete',
+        deleted: 0
+      });
+    }
+
+    // Log what we're about to delete
+    console.log(`🗑️ Deleting ${feedIdsToDelete.length} feeds...`);
+    stats.toDelete.feeds.forEach(f => {
+      console.log(`  - ${f.title} (${f.artist})`);
+    });
+
+    // Delete tracks first (should cascade, but being explicit)
+    const deletedTracks = await prisma.track.deleteMany({
+      where: { feedId: { in: feedIdsToDelete } }
+    });
+
+    // Delete the feeds
+    const deletedFeeds = await prisma.feed.deleteMany({
+      where: { id: { in: feedIdsToDelete } }
+    });
+
+    console.log(`✅ Cleanup complete: ${deletedFeeds.count} feeds, ${deletedTracks.count} tracks deleted`);
+
+    return NextResponse.json({
+      success: true,
+      message: 'Cleanup completed',
+      deleted: {
+        feeds: deletedFeeds.count,
+        tracks: deletedTracks.count
+      },
+      deletedFeedTitles: stats.toDelete.feeds.map(f => `${f.title} - ${f.artist}`)
+    });
+
+  } catch (error) {
+    console.error('❌ Cleanup error:', error);
+    return NextResponse.json(
+      { error: 'Failed to execute cleanup', details: error instanceof Error ? error.message : 'Unknown' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/albums-fast/route.ts
+++ b/app/api/albums-fast/route.ts
@@ -3,6 +3,7 @@ import { prisma } from '@/lib/prisma';
 import { Track } from '@prisma/client';
 import { getPlaylistUrls, getAllPlaylistIds } from '@/lib/playlist/configs';
 import { getBlacklistedFeedIds, BLACKLISTED_FEED_URLS } from '@/lib/feed-exclusions';
+import { isV4VTagsEnabled } from '@/lib/flags';
 import {
   CACHE_DURATION,
   PLAYLIST_CACHE_DURATION,
@@ -12,6 +13,31 @@ import {
 } from '@/lib/caches/albums-fast-cache';
 
 const cache = getAlbumsFastCache();
+
+// Shared Track select for the grid (both the general branch and the 'podcasts' case).
+// Keep this in sync at ONE place — the two-block gotcha in CLAUDE.md L160 used to hit here.
+// The v4v tag join is intentionally NOT included: chips render on the album detail page,
+// not the grid, and joining here adds measurable latency (observed 12s spike in dev).
+const ALBUMS_FAST_TRACK_SELECT = {
+  id: true,
+  guid: true,
+  title: true,
+  duration: true,
+  audioUrl: true,
+  image: true,
+  publishedAt: true,
+  v4vRecipient: true,
+  v4vValue: true,
+  startTime: true,
+  endTime: true,
+  trackOrder: true,
+  mediaType: true,
+  alternateEnclosures: true,
+  chaptersUrl: true,
+  chapters: true,
+  valueTimeSplits: true,
+  persons: true,
+} as const;
 
 // Function to get playlist albums
 async function getPlaylistAlbums() {
@@ -83,6 +109,10 @@ export async function GET(request: Request) {
     const offset = parseInt(searchParams.get('offset') || '0');
     const filter = searchParams.get('filter') || 'all'; // albums, eps, singles, all
     const sort = searchParams.get('sort') || 'default'; // Sort order: name-asc, added-desc, year-desc, etc.
+    const genre = searchParams.get('genre') || null; // Genre filter (matches Feed.podcastCategories[])
+    // V4V Music tag feature is gated by env until the add_v4v_tags migration is applied.
+    const v4vTagsEnabled = isV4VTagsEnabled();
+    const tag = v4vTagsEnabled ? (searchParams.get('tag') || null) : null;
     const forceRefresh = searchParams.get('refresh') === 'true'; // Force cache refresh
 
     // Clear cache if refresh requested
@@ -109,23 +139,29 @@ export async function GET(request: Request) {
     }
     
     const now = Date.now();
-    const shouldRefreshCache = !cache.data || (now - cache.timestamp) > CACHE_DURATION;
+    // Skip the in-memory cache when genre/tag filter is applied — DB does the work.
+    const shouldRefreshCache = !cache.data || (now - cache.timestamp) > CACHE_DURATION || !!genre || !!tag;
 
     let feeds: FeedWithTracks[];
     let publisherStats: Array<{ name: string; albumCount: number }>;
-    
+
+    // Build the feed-level where clause once and reuse for both query branches
+    const feedWhere: any = { status: 'active' };
+    if (genre) feedWhere.podcastCategories = { has: genre };
+    if (tag) feedWhere.Track = { some: { tags: { some: { Tag: { name: tag } } } } };
+
     if (shouldRefreshCache) {
       if (process.env.NODE_ENV === 'development') {
-        console.log('🔄 Fetching albums from database...');
+        console.log('🔄 Fetching albums from database...', genre || tag ? `(genre=${genre ?? '-'}, tag=${tag ?? '-'})` : '');
       }
-      
+
       // Load all feeds to maintain global sort order
       // Pagination happens after sorting, not at the database level
-      
+
       try {
         // Fetch feeds with minimal track data (optimized select)
         feeds = await prisma.feed.findMany({
-          where: { status: 'active' },
+          where: feedWhere,
           select: {
             id: true,
             guid: true,
@@ -143,31 +179,13 @@ export async function GET(request: Request) {
             v4vRecipient: true,
             v4vValue: true,
             persons: true,
+            podcastCategories: true,
             Track: {
               where: {
                 audioUrl: { not: '' },
                 status: 'active'
               },
-              select: {
-                id: true,
-                guid: true,
-                title: true,
-                duration: true,
-                audioUrl: true,
-                image: true,
-                publishedAt: true,
-                v4vRecipient: true,
-                v4vValue: true,
-                startTime: true,
-                endTime: true,
-                trackOrder: true,
-                mediaType: true,
-                alternateEnclosures: true,
-                chaptersUrl: true,
-                chapters: true,
-                valueTimeSplits: true,
-                persons: true,
-              },
+              select: ALBUMS_FAST_TRACK_SELECT,
               orderBy: [
                 { trackOrder: 'asc' },
                 { publishedAt: 'asc' },
@@ -183,7 +201,7 @@ export async function GET(request: Request) {
             { priority: 'asc' },
             { createdAt: 'desc' }
           ]
-        }) as FeedWithTracks[];
+        }) as unknown as FeedWithTracks[];
       } catch (queryError) {
         console.error('❌ Database query error:', queryError);
         // Return cached data if available, or empty result
@@ -222,9 +240,9 @@ export async function GET(request: Request) {
         publisherStats = [];
       }
       
-      // Cache the results only for 'all' filter with no pagination (first page)
+      // Cache the results only for 'all' filter with no pagination (first page) and no genre/tag filter
       // This provides fast cache hits for common initial load
-      const shouldCache = filter === 'all' && offset === 0 && limit >= 50;
+      const shouldCache = filter === 'all' && offset === 0 && limit >= 50 && !genre && !tag;
       if (shouldCache) {
         cache.data = { feeds, publisherStats };
         cache.timestamp = now;
@@ -298,6 +316,7 @@ export async function GET(request: Request) {
       v4vRecipient: feed.v4vRecipient || feed.Track?.[0]?.v4vRecipient || null,
       v4vValue: feed.v4vValue || feed.Track?.[0]?.v4vValue || null,
       persons: (feed as any).persons || undefined,
+      podcastCategories: (feed as any).podcastCategories || [],
       // Actual track count from database (tracks array may be limited)
       trackCount: feed._count.Track
     }));
@@ -420,6 +439,8 @@ export async function GET(request: Request) {
             where: {
               status: 'active',
               type: 'podcast',
+              ...(genre ? { podcastCategories: { has: genre } } : {}),
+              ...(tag ? { Track: { some: { tags: { some: { Tag: { name: tag } } } } } } : {}),
             },
             select: {
               id: true,
@@ -438,28 +459,10 @@ export async function GET(request: Request) {
               v4vRecipient: true,
               v4vValue: true,
               persons: true,
+              podcastCategories: true,
               Track: {
                 where: { audioUrl: { not: '' }, status: 'active' },
-                select: {
-                  id: true,
-                  guid: true,
-                  title: true,
-                  duration: true,
-                  audioUrl: true,
-                  image: true,
-                  publishedAt: true,
-                  v4vRecipient: true,
-                  v4vValue: true,
-                  startTime: true,
-                  endTime: true,
-                  trackOrder: true,
-                  mediaType: true,
-                  alternateEnclosures: true,
-                  chaptersUrl: true,
-                  chapters: true,
-                  valueTimeSplits: true,
-                  persons: true,
-                },
+                select: ALBUMS_FAST_TRACK_SELECT,
                 orderBy: [
                   { trackOrder: 'asc' },
                   { publishedAt: 'asc' },
@@ -518,6 +521,7 @@ export async function GET(request: Request) {
             v4vRecipient: feed.v4vRecipient,
             v4vValue: feed.v4vValue,
             persons: (feed as any).persons || undefined,
+            podcastCategories: (feed as any).podcastCategories || [],
           };
           });
           break;

--- a/app/api/albums/[slug]/route.ts
+++ b/app/api/albums/[slug]/route.ts
@@ -3,6 +3,7 @@ import { prisma } from '@/lib/prisma';
 import { generateAlbumSlug, getPublisherInfo } from '@/lib/url-utils';
 import { getAllPlaylistIds, getPlaylistUrls, getPlaylistConfig, PLAYLIST_CONFIGS } from '@/lib/playlist/configs';
 import { PODCAST_FEED_IDS, PODCAST_FEED_URLS } from '@/lib/podcast-feeds';
+import { isV4VTagsEnabled } from '@/lib/flags';
 
 const ITDV_PLAYLIST_URL = 'https://raw.githubusercontent.com/ChadFarrow/chadf-musicl-playlists/refs/heads/main/docs/ITDV-music-playlist.xml';
 const HGH_PLAYLIST_URL = 'https://raw.githubusercontent.com/ChadFarrow/chadf-musicl-playlists/refs/heads/main/docs/HGH-music-playlist.xml';
@@ -162,6 +163,7 @@ const TRACK_SELECT_FIELDS = {
   chaptersUrl: true,
   chapters: true,
   valueTimeSplits: true,
+  ...(isV4VTagsEnabled() ? { tags: { select: { Tag: { select: { name: true } } } } } : {}),
 } as const;
 
 // Map a DB track to the API response format
@@ -189,6 +191,7 @@ function mapTrackToResponse(track: any, fallbackImage: string | null, index: num
     chapters: track.chapters || undefined,
     valueTimeSplits: track.valueTimeSplits || undefined,
     publishedAt: track.publishedAt || null,
+    tags: track.tags?.map((tt: any) => tt.Tag.name) || [],
   };
 }
 

--- a/app/api/cron/ingest-v4v-tags/route.ts
+++ b/app/api/cron/ingest-v4v-tags/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from 'next/server';
+import { ingestV4vTags } from '@/lib/v4v-tags-ingest';
+import { isV4VTagsEnabled } from '@/lib/flags';
+
+export const dynamic = 'force-dynamic';
+// v4vmusic /items/bytag is slow (30s+ per popular tag). 200 tags @ 3-parallel @ 90s = up to ~100 min worst case.
+export const maxDuration = 1800;
+
+// Optional bearer-token gate: set CRON_SECRET in env to require it.
+function isAuthorized(request: Request): boolean {
+  const expected = process.env.CRON_SECRET;
+  if (!expected) return true;
+  const header = request.headers.get('authorization') || '';
+  return header === `Bearer ${expected}`;
+}
+
+async function run(request: Request) {
+  if (!isV4VTagsEnabled()) {
+    return NextResponse.json({ error: 'v4v tags feature disabled (set V4V_TAGS_ENABLED=true after running add_v4v_tags migration)' }, { status: 503 });
+  }
+  if (!isAuthorized(request)) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+  const { searchParams } = new URL(request.url);
+  const limit = Math.min(parseInt(searchParams.get('limit') || '200'), 500);
+
+  try {
+    const result = await ingestV4vTags({ limit });
+    return NextResponse.json({ success: true, ...result });
+  } catch (err) {
+    console.error('v4v ingest failed:', err);
+    return NextResponse.json({ success: false, error: (err as Error).message }, { status: 500 });
+  }
+}
+
+export const GET = run;
+export const POST = run;

--- a/app/api/genres/route.ts
+++ b/app/api/genres/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+
+export const dynamic = 'force-dynamic';
+
+// Upstream parsers leak these sentinel strings into podcastCategories.
+const JUNK_VALUES = new Set(['null', 'undefined', 'nan', 'none', '-']);
+
+// Minimal HTML-entity decode; some feeds leave "&amp;" / "&#039;" etc. unescaped.
+function decodeEntities(s: string): string {
+  return s
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#0?39;/g, "'")
+    .replace(/&apos;/g, "'");
+}
+
+// GET /api/genres - Get list of unique genres with counts
+export async function GET() {
+  try {
+    // Only count categories on active, non-podcast, non-publisher feeds that the album grid actually surfaces.
+    const feedsWithCategories = await prisma.feed.findMany({
+      where: {
+        status: 'active',
+        type: { notIn: ['podcast', 'publisher'] },
+        podcastCategories: { isEmpty: false }
+      },
+      select: {
+        podcastCategories: true
+      }
+    });
+
+    // Count occurrences of each genre
+    const genreCounts = new Map<string, number>();
+
+    for (const feed of feedsWithCategories) {
+      for (const genre of feed.podcastCategories) {
+        if (!genre) continue;
+        const cleaned = decodeEntities(genre.trim());
+        if (!cleaned) continue;
+        if (JUNK_VALUES.has(cleaned.toLowerCase())) continue;
+        genreCounts.set(cleaned, (genreCounts.get(cleaned) || 0) + 1);
+      }
+    }
+
+    // Convert to array and sort by count (descending)
+    const genres = Array.from(genreCounts.entries())
+      .map(([name, count]) => ({ name, count }))
+      .sort((a, b) => b.count - a.count);
+
+    return NextResponse.json({
+      genres,
+      total: genres.length
+    });
+
+  } catch (error) {
+    console.error('Error fetching genres:', error);
+    return NextResponse.json(
+      { error: 'Failed to fetch genres' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/tags/route.ts
+++ b/app/api/tags/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { isV4VTagsEnabled } from '@/lib/flags';
+
+export const dynamic = 'force-dynamic';
+
+// GET /api/tags - Popular V4V Music tags mirrored into our DB.
+// Mirrors the shape of /api/genres so the UI can treat them symmetrically.
+export async function GET(request: Request) {
+  // Feature is gated by env until the add_v4v_tags migration is applied.
+  if (!isV4VTagsEnabled()) {
+    return NextResponse.json({ tags: [], total: 0, disabled: true });
+  }
+  try {
+    const { searchParams } = new URL(request.url);
+    const limit = Math.min(parseInt(searchParams.get('limit') || '200'), 500);
+
+    // Count only TrackTag rows whose parent Feed is active — matches what the grid actually shows.
+    // The denormalized Tag.count can include orphan rows from error/deleted feeds.
+    const grouped = await prisma.trackTag.groupBy({
+      by: ['tagId'],
+      where: { Track: { Feed: { status: 'active' } } },
+      _count: { tagId: true },
+    });
+    const countsById = new Map(grouped.map(g => [g.tagId, g._count.tagId]));
+    const activeIds = Array.from(countsById.keys());
+    if (activeIds.length === 0) return NextResponse.json({ tags: [], total: 0 });
+
+    const rows = await prisma.tag.findMany({
+      where: { id: { in: activeIds } },
+      select: { id: true, name: true },
+    });
+    const tags = rows
+      .map(r => ({ name: r.name, count: countsById.get(r.id) || 0 }))
+      .filter(t => t.count > 0)
+      .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name))
+      .slice(0, limit);
+
+    return NextResponse.json({ tags, total: tags.length });
+  } catch (error) {
+    console.error('Error fetching tags:', error);
+    return NextResponse.json({ error: 'Failed to fetch tags' }, { status: 500 });
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,8 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 import LoadingSpinner from '@/components/LoadingSpinner';
+import FilterDropdown from '@/components/FilterDropdown';
+import { useFilterDropdown } from '@/components/useFilterDropdown';
 import { RSSAlbum } from '@/lib/rss-parser';
 import { getAlbumArtworkUrl, getPlaceholderImageUrl } from '@/lib/cdn-utils';
 import { generateAlbumUrl, generatePublisherSlug } from '@/lib/url-utils';
@@ -165,14 +167,26 @@ function HomePageContent() {
   // Format-aware loading state (for "all" filter - load all albums before EPs)
   const [formatCounts, setFormatCounts] = useState<{ albums: number; eps: number; singles: number } | null>(null);
   const [currentFormatPhase, setCurrentFormatPhase] = useState<'albums' | 'eps' | 'singles'>('albums');
-  const API_VERSION = 'v13'; // v13: added persons (podcast:person with npub) on track + feed; consumed for Nostr p-tags on boosts
+  const API_VERSION = 'v14'; // v14: added podcastCategories on feed and v4vmusic tags on track
+
+  // Genre + V4V Music tag filter state — lazy-fetched options live inside the hook.
+  const urlGenre = searchParams?.get('genre') || null;
+  const urlTag = searchParams?.get('tag') || null;
+  const genreFilter = useFilterDropdown({ fetchUrl: '/api/genres', responseKey: 'genres', initial: urlGenre, delayMs: 600 });
+  const tagFilter = useFilterDropdown({ fetchUrl: '/api/tags',   responseKey: 'tags',   initial: urlTag,   delayMs: 800 });
+  const selectedGenre = genreFilter.selected;
+  const selectedTag = tagFilter.selected;
+  // Mutual exclusion: picking one clears the other.
+  const pickGenre = (v: string | null) => { genreFilter.setSelected(v); if (v) tagFilter.setSelected(null); };
+  const pickTag   = (v: string | null) => { tagFilter.setSelected(v);   if (v) genreFilter.setSelected(null); };
   
   // HGH filter removed - no longer needed
   
   // Global audio context
   const { playAlbum: globalPlayAlbum, shuffleAllTracks } = useAudio();
   const hasLoadedRef = useRef(false);
-  const isUpdatingFromUrlRef = useRef(false); // Track if we're updating from URL to avoid loops
+  // Lock: prevents the URL-sync effect from re-firing handleFilterChange while a filter change is already in flight.
+  const isUpdatingFromUrlRef = useRef(false);
   
 
   
@@ -188,7 +202,7 @@ function HomePageContent() {
   const [activeFilter, setActiveFilter] = useState<FilterType>(initialFilter);
 
   // Store handleFilterChange in a ref to avoid dependency issues
-  const handleFilterChangeRef = useRef<((newFilter: FilterType, skipUrlUpdate?: boolean) => Promise<void>) | null>(null);
+  const handleFilterChangeRef = useRef<((newFilter: FilterType, skipUrlUpdate?: boolean, forceReload?: boolean) => Promise<void>) | null>(null);
   
   // Sync filter from URL params when URL changes (e.g., browser back button)
   useEffect(() => {
@@ -275,7 +289,7 @@ function HomePageContent() {
       setCurrentPage(1);
       setHasMoreAlbums(true);
       try {
-        const { albums, totalCount } = await loadAlbumsData('all', ALBUMS_PER_PAGE, 0, activeFilter);
+        const { albums, totalCount } = await loadAlbumsData('all', ALBUMS_PER_PAGE, 0, activeFilter, selectedGenre, selectedTag);
         setDisplayedAlbums(albums);
         setEnhancedAlbums(albums);
         setCriticalAlbums(albums.slice(0, 12));
@@ -336,7 +350,55 @@ function HomePageContent() {
 
 
   // Audio playback is now handled by the global AudioContext
-  
+
+  // (Lazy-fetch of genres + tags and outside-click handling now live in useFilterDropdown + FilterDropdown.)
+
+  // Reload grid + sync URL when genre or tag changes (skip first mount).
+  // Bypasses handleFilterChange's cache layers — fetches fresh and commits state directly.
+  const isGenreTagInitialMountRef = useRef(false);
+  useEffect(() => {
+    if (!isGenreTagInitialMountRef.current) {
+      isGenreTagInitialMountRef.current = true;
+      return;
+    }
+    // Sync to URL
+    const params = new URLSearchParams(searchParams?.toString() || '');
+    if (selectedGenre) params.set('genre', selectedGenre); else params.delete('genre');
+    if (selectedTag) params.set('tag', selectedTag); else params.delete('tag');
+    const qs = params.toString();
+    router.replace(qs ? `/?${qs}` : '/', { scroll: false });
+
+    // Skip reload for filters where genre/tag don't apply
+    if (activeFilter === 'publishers' || activeFilter === 'playlist') return;
+
+    let cancelled = false;
+    setIsLoading(true);
+    setIsFilterLoading(true);
+    (async () => {
+      try {
+        const { albums, totalCount } = await loadAlbumsData('all', ALBUMS_PER_PAGE, 0, activeFilter, selectedGenre, selectedTag);
+        if (cancelled) return;
+        setCurrentPage(1);
+        setDisplayedAlbums(albums);
+        setCriticalAlbums(albums.slice(0, 12));
+        setEnhancedAlbums(albums);
+        setTotalAlbums(totalCount);
+        setHasMoreAlbums(albums.length < totalCount);
+        setIsCriticalLoaded(true);
+        setIsEnhancedLoaded(true);
+      } catch (err) {
+        console.error('genre/tag refresh failed', err);
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+          setIsFilterLoading(false);
+        }
+      }
+    })();
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedGenre, selectedTag]);
+
   useEffect(() => {
     // Prevent multiple loads
     if (hasLoadedRef.current) {
@@ -428,7 +490,7 @@ function HomePageContent() {
       // OPTIMIZED: Load albums in single API call (includes totalCount in response)
       // Removed redundant count query - totalCount is now included in albums response
       const startIndex = (currentPage - 1) * ALBUMS_PER_PAGE;
-      const { albums: pageAlbums, totalCount } = await loadAlbumsData('all', ALBUMS_PER_PAGE, startIndex, activeFilter);
+      const { albums: pageAlbums, totalCount } = await loadAlbumsData('all', ALBUMS_PER_PAGE, startIndex, activeFilter, selectedGenre, selectedTag);
       
       // Update total albums count from API response (for pagination)
       setTotalAlbums(totalCount);
@@ -531,7 +593,7 @@ function HomePageContent() {
         }
 
         // Load next page from API (server-side sorted globally: Albums → EPs → Singles)
-        const { albums: newAlbums, totalCount: newTotalCount } = await loadAlbumsData('all', loadLimit, startIndex, activeFilter);
+        const { albums: newAlbums, totalCount: newTotalCount } = await loadAlbumsData('all', loadLimit, startIndex, activeFilter, selectedGenre, selectedTag);
 
         // Update totalAlbums if we got a new total count (should be the same, but ensure consistency)
         if (newTotalCount > 0) {
@@ -608,13 +670,13 @@ function HomePageContent() {
   }, [hasMoreAlbums, isLoading, isEnhancedLoaded, loadMoreAlbums]);
 
   // Handle filter changes - reload data and reset to page 1
-  const handleFilterChange = async (newFilter: FilterType, skipUrlUpdate = false) => {
+  const handleFilterChange = async (newFilter: FilterType, skipUrlUpdate = false, forceReload = false) => {
     if (process.env.NODE_ENV === 'development') {
-      console.log(`🔄 handleFilterChange called with filter: "${newFilter}"`);
+      console.log(`🔄 handleFilterChange called with filter: "${newFilter}" forceReload=${forceReload}`);
     }
 
-    // Check if filter is the same AND we already have data
-    if (newFilter === activeFilter) {
+    // Check if filter is the same AND we already have data (skip when forceReload, e.g. genre/tag change)
+    if (newFilter === activeFilter && !forceReload) {
       const hasData = displayedAlbums.length > 0 || enhancedAlbums.length > 0 || criticalAlbums.length > 0;
       if (hasData) {
         if (process.env.NODE_ENV === 'development') {
@@ -629,6 +691,12 @@ function HomePageContent() {
 
     // Set activeFilter immediately so UI updates right away
     setActiveFilter(newFilter);
+
+    // Genre/Tag don't apply to publishers or playlists — clear them and close the menus.
+    if (newFilter === 'publishers' || newFilter === 'playlist') {
+      if (selectedGenre) genreFilter.setSelected(null);
+      if (selectedTag) tagFilter.setSelected(null);
+    }
 
     // When switching to publishers or playlist, ensure sortType is valid for reduced options
     const optsForFilter = newFilter === 'publishers' ? SORT_OPTIONS_PUBLISHERS : newFilter === 'playlist' ? SORT_OPTIONS_PLAYLIST : null;
@@ -655,8 +723,8 @@ function HomePageContent() {
       router.push(newUrl, { scroll: false });
     }
 
-    // Check cache first
-    const cachedData = filterCache.get(newFilter);
+    // Check cache first (skip when forceReload — e.g. genre/tag changed)
+    const cachedData = forceReload ? null : filterCache.get(newFilter);
     if (cachedData) {
       if (process.env.NODE_ENV === 'development') {
         console.log(`📦 Using cached data for filter: ${newFilter}`);
@@ -708,7 +776,7 @@ function HomePageContent() {
         };
       } else if (newFilter === 'playlist') {
         // Special handling for playlist filter - multiple playlists
-        const { albums: pageAlbums, totalCount } = await loadAlbumsData('all', ALBUMS_PER_PAGE, 0, newFilter);
+        const { albums: pageAlbums, totalCount } = await loadAlbumsData('all', ALBUMS_PER_PAGE, 0, newFilter, selectedGenre, selectedTag);
         
         resultData = {
           albums: pageAlbums,
@@ -717,7 +785,7 @@ function HomePageContent() {
         };
       } else {
         // Single fetch - loadAlbumsData already returns totalCount
-        const { albums: pageAlbums, totalCount } = await loadAlbumsData('all', ALBUMS_PER_PAGE, 0, newFilter);
+        const { albums: pageAlbums, totalCount } = await loadAlbumsData('all', ALBUMS_PER_PAGE, 0, newFilter, selectedGenre, selectedTag);
 
         resultData = {
           albums: pageAlbums,
@@ -761,7 +829,7 @@ function HomePageContent() {
   const totalPages = Math.ceil(totalAlbums / ALBUMS_PER_PAGE);
   const loadedAlbumsCount = displayedAlbums.length;
 
-  const loadAlbumsData = async (loadTier: 'core' | 'extended' | 'lowPriority' | 'all' = 'all', limit: number = 50, offset: number = 0, filter: string = 'all'): Promise<{ albums: RSSAlbum[]; totalCount: number }> => {
+  const loadAlbumsData = async (loadTier: 'core' | 'extended' | 'lowPriority' | 'all' = 'all', limit: number = 50, offset: number = 0, filter: string = 'all', genre: string | null = null, tag: string | null = null): Promise<{ albums: RSSAlbum[]; totalCount: number }> => {
     try {
       // Handle publishers filter separately - don't call albums API for publishers
       if (filter === 'publishers') {
@@ -950,8 +1018,8 @@ function HomePageContent() {
         }
       }
       
-      // Simplified caching - only cache the main 'all' request with no filtering
-      if (typeof window !== 'undefined' && loadTier === 'all' && offset === 0 && filter === 'all' && sortType === 'name-asc') {
+      // Simplified caching - only cache the main 'all' request with no filtering (no genre/tag set either)
+      if (typeof window !== 'undefined' && loadTier === 'all' && offset === 0 && filter === 'all' && sortType === 'name-asc' && !genre && !tag) {
         const cached = localStorage.getItem(`cachedAlbums_${ALBUMS_PER_PAGE}_${API_VERSION}`);
         const timestamp = localStorage.getItem(`albumsCacheTimestamp_${ALBUMS_PER_PAGE}_${API_VERSION}`);
         
@@ -989,6 +1057,8 @@ function HomePageContent() {
       if (sortType !== 'name-asc') {
         params.set('sort', sortType);
       }
+      if (genre) params.set('genre', genre);
+      if (tag) params.set('tag', tag);
       
       if (process.env.NODE_ENV === 'development') {
         console.log(`🌐 Fetching: /api/albums-fast?${params}`);
@@ -1074,8 +1144,8 @@ function HomePageContent() {
         rssAlbums = rssAlbums.slice(0, limit);
       }
       
-      // Cache only the main 'all' request for performance - but only if we have publisher stats
-      if (typeof window !== 'undefined' && loadTier === 'all' && offset === 0 && filter === 'all' && publisherStatsFromAPI.length > 0) {
+      // Cache only the main 'all' request for performance - but only if we have publisher stats and no genre/tag filter
+      if (typeof window !== 'undefined' && loadTier === 'all' && offset === 0 && filter === 'all' && publisherStatsFromAPI.length > 0 && !genre && !tag) {
         try {
           localStorage.setItem(`cachedAlbums_${ALBUMS_PER_PAGE}_${API_VERSION}`, JSON.stringify(rssAlbums));
           localStorage.setItem(`albumsCacheTimestamp_${ALBUMS_PER_PAGE}_${API_VERSION}`, Date.now().toString());
@@ -1519,7 +1589,7 @@ function HomePageContent() {
               </select>
 
               {/* Desktop: Button tabs */}
-              <div className="hidden md:flex gap-1">
+              <div className="hidden md:flex gap-1 items-center">
                 {[
                   { value: 'all', label: 'All' },
                   { value: 'albums', label: 'Albums' },
@@ -1543,6 +1613,25 @@ function HomePageContent() {
                     {filter.label}
                   </button>
                 ))}
+
+                {/* Genre + V4V Music Tag dropdowns — hidden for filters where they don't apply */}
+                {activeFilter !== 'publishers' && activeFilter !== 'playlist' && (
+                  <>
+                    <FilterDropdown
+                      label="Genre"
+                      selected={selectedGenre}
+                      options={genreFilter.options}
+                      onSelect={pickGenre}
+                      className="ml-1"
+                    />
+                    <FilterDropdown
+                      label="Tag"
+                      selected={selectedTag}
+                      options={tagFilter.options}
+                      onSelect={pickTag}
+                    />
+                  </>
+                )}
               </div>
 
               {/* Right side - Action buttons */}

--- a/components/FilterDropdown.tsx
+++ b/components/FilterDropdown.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+export interface FilterOption {
+  name: string;
+  count: number;
+}
+
+interface FilterDropdownProps {
+  label: string;                       // "Genre", "Tag"
+  selected: string | null;
+  options: FilterOption[];
+  onSelect: (next: string | null) => void;
+  clearAriaLabel?: string;             // e.g. "Clear genre filter"
+  className?: string;                  // for the outer wrapper (e.g. "ml-1")
+}
+
+/**
+ * Pill dropdown that slots into the top filter bar. Owns its own open state,
+ * ref, and outside-click handler. Visual parity with the bare filter pills.
+ */
+export default function FilterDropdown({
+  label,
+  selected,
+  options,
+  onSelect,
+  clearAriaLabel,
+  className = '',
+}: FilterDropdownProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [isOpen]);
+
+  if (options.length === 0) return null;
+
+  const pillClasses = `px-3 py-2 rounded text-sm font-medium whitespace-nowrap transition-all ${
+    selected ? 'bg-stablekraft-teal text-white shadow-sm' : 'text-gray-300 hover:text-white hover:bg-gray-700'
+  }`;
+
+  return (
+    <div className={`relative ${className}`} ref={ref}>
+      <button
+        type="button"
+        onClick={() => setIsOpen((v) => !v)}
+        className={pillClasses}
+        aria-expanded={isOpen}
+        aria-haspopup="listbox"
+      >
+        {selected ? `${label}: ${selected}` : `${label} ▾`}
+        {selected && (
+          <span
+            role="button"
+            aria-label={clearAriaLabel ?? `Clear ${label.toLowerCase()} filter`}
+            className="ml-2 text-white/80 hover:text-white"
+            onClick={(e) => { e.stopPropagation(); onSelect(null); setIsOpen(false); }}
+          >×</span>
+        )}
+      </button>
+      {isOpen && (
+        <div
+          role="listbox"
+          className="absolute left-0 top-full z-40 mt-2 w-64 max-h-80 overflow-y-auto rounded-lg bg-zinc-900 border border-white/10 shadow-xl"
+        >
+          {options.map((opt) => (
+            <button
+              key={opt.name}
+              type="button"
+              role="option"
+              aria-selected={selected === opt.name}
+              onClick={() => {
+                const next = opt.name === selected ? null : opt.name;
+                onSelect(next);
+                setIsOpen(false);
+              }}
+              className={`w-full text-left px-3 py-2 text-sm flex items-center justify-between hover:bg-white/10 ${
+                selected === opt.name ? 'bg-white/5 text-white' : 'text-white/80'
+              }`}
+            >
+              <span className="truncate">{opt.name}</span>
+              <span className="ml-2 text-xs text-white/50">{opt.count}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/useFilterDropdown.ts
+++ b/components/useFilterDropdown.ts
@@ -1,0 +1,50 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import type { FilterOption } from './FilterDropdown';
+
+interface UseFilterDropdownOpts {
+  fetchUrl: string;                       // e.g. '/api/genres'
+  responseKey: string;                    // key inside response holding the array (e.g. 'genres', 'tags')
+  initial: string | null;                 // URL-param seed on mount
+  delayMs?: number;                       // lazy-fetch delay so main grid loads first
+}
+
+interface UseFilterDropdownReturn {
+  selected: string | null;
+  setSelected: (v: string | null) => void;
+  options: FilterOption[];
+}
+
+/**
+ * Owns selected-state + lazy-fetched options for a filter dropdown.
+ * Intentionally does NOT know about mutual exclusion — the parent wires
+ * that across multiple hook instances where both setters are visible.
+ */
+export function useFilterDropdown({
+  fetchUrl,
+  responseKey,
+  initial,
+  delayMs = 600,
+}: UseFilterDropdownOpts): UseFilterDropdownReturn {
+  const [selected, setSelected] = useState<string | null>(initial);
+  const [options, setOptions] = useState<FilterOption[]>([]);
+
+  useEffect(() => {
+    if (options.length > 0) return;
+    const t = setTimeout(async () => {
+      try {
+        const res = await fetch(fetchUrl);
+        if (!res.ok) return;
+        const data = await res.json();
+        const items = data?.[responseKey];
+        if (Array.isArray(items)) setOptions(items);
+      } catch { /* silent — dropdown just stays hidden */ }
+    }, delayMs);
+    return () => clearTimeout(t);
+    // Intentional: fetch is one-shot; deps tie to options length only to skip re-runs.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [options.length]);
+
+  return { selected, setSelected, options };
+}

--- a/lib/flags.ts
+++ b/lib/flags.ts
@@ -1,0 +1,3 @@
+// Feature flags. Function form keeps the env lookup dynamic (for tests / hot reload).
+
+export const isV4VTagsEnabled = () => process.env.V4V_TAGS_ENABLED === 'true';

--- a/lib/v4v-tags-ingest.ts
+++ b/lib/v4v-tags-ingest.ts
@@ -1,0 +1,103 @@
+import { prisma } from '@/lib/prisma';
+
+const V4V_BASE = 'https://v4vmusic.com';
+// v4vmusic /items/bytag responses can take 30+ seconds for popular tags. Generous timeout required.
+const FETCH_TIMEOUT_MS = 90_000;
+const PARALLEL_BATCH = 3;
+
+export interface PopularTag { name: string; count: number; }
+export interface V4vItem { feedGuid: string; itemGuid: string; title?: string; artistName?: string; }
+
+export interface IngestResult {
+  tagsFetched: number;
+  itemsProcessed: number;
+  tracksMatched: number;
+  itemsSkipped: number;
+  durationMs: number;
+}
+
+async function fetchJson<T>(url: string): Promise<T | null> {
+  try {
+    const res = await fetch(url, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
+    if (!res.ok) return null;
+    return await res.json() as T;
+  } catch {
+    return null;
+  }
+}
+
+export async function ingestV4vTags(opts: { limit?: number; logger?: (msg: string) => void } = {}): Promise<IngestResult> {
+  const limit = opts.limit ?? 200;
+  const log = opts.logger ?? (() => {});
+  const t0 = Date.now();
+
+  const popular = await fetchJson<{ tags: PopularTag[] }>(`${V4V_BASE}/api/public/tags/popular?limit=${limit}`);
+  if (!popular?.tags?.length) {
+    return { tagsFetched: 0, itemsProcessed: 0, tracksMatched: 0, itemsSkipped: 0, durationMs: Date.now() - t0 };
+  }
+  log(`Got ${popular.tags.length} popular tags`);
+
+  const allFeeds = await prisma.feed.findMany({ select: { id: true, guid: true } });
+  const feedByGuid = new Map<string, string>();
+  for (const f of allFeeds) {
+    if (f.guid) feedByGuid.set(f.guid, f.id);
+  }
+
+  const tagIdByName = new Map<string, number>();
+  const now = new Date();
+  for (const t of popular.tags) {
+    const tag = await prisma.tag.upsert({
+      where: { name: t.name },
+      create: { name: t.name, count: 0, source: 'v4vmusic', updatedAt: now },
+      update: { updatedAt: now },
+      select: { id: true, name: true },
+    });
+    tagIdByName.set(tag.name, tag.id);
+  }
+
+  let tracksMatched = 0;
+  let itemsSkipped = 0;
+  let itemsProcessed = 0;
+
+  for (let i = 0; i < popular.tags.length; i += PARALLEL_BATCH) {
+    const batch = popular.tags.slice(i, i + PARALLEL_BATCH);
+    await Promise.all(batch.map(async (t) => {
+      const items = await fetchJson<V4vItem[]>(`${V4V_BASE}/api/public/items/bytag/${encodeURIComponent(t.name)}`);
+      if (!Array.isArray(items)) return;
+      itemsProcessed += items.length;
+      const tagId = tagIdByName.get(t.name);
+      if (!tagId) return;
+
+      for (const item of items) {
+        if (!item.feedGuid || !item.itemGuid) { itemsSkipped++; continue; }
+        const feedId = feedByGuid.get(item.feedGuid);
+        if (!feedId) { itemsSkipped++; continue; }
+        const track = await prisma.track.findFirst({
+          where: { feedId, guid: item.itemGuid },
+          select: { id: true },
+        });
+        if (!track) { itemsSkipped++; continue; }
+        await prisma.trackTag.upsert({
+          where: { trackId_tagId: { trackId: track.id, tagId } },
+          create: { trackId: track.id, tagId, source: 'v4vmusic' },
+          update: {},
+        });
+        tracksMatched++;
+      }
+    }));
+  }
+
+  // Refresh denormalized counts
+  for (const [, tagId] of tagIdByName) {
+    const count = await prisma.trackTag.count({ where: { tagId } });
+    await prisma.tag.update({ where: { id: tagId }, data: { count, updatedAt: new Date() } });
+  }
+
+  return {
+    tagsFetched: popular.tags.length,
+    itemsProcessed,
+    tracksMatched,
+    itemsSkipped,
+    durationMs: Date.now() - t0,
+  };
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "podcast-music-site",
-  "version": "1.2a9078bf8",
+  "version": "1.2a019f0535",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/prisma/migrations/20260422000000_add_v4v_tags/migration.sql
+++ b/prisma/migrations/20260422000000_add_v4v_tags/migration.sql
@@ -1,0 +1,39 @@
+-- CreateTable
+CREATE TABLE "Tag" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "count" INTEGER NOT NULL DEFAULT 0,
+    "source" TEXT NOT NULL DEFAULT 'v4vmusic',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Tag_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "TrackTag" (
+    "trackId" TEXT NOT NULL,
+    "tagId" INTEGER NOT NULL,
+    "source" TEXT NOT NULL DEFAULT 'v4vmusic',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "TrackTag_pkey" PRIMARY KEY ("trackId","tagId")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Tag_name_key" ON "Tag"("name");
+
+-- CreateIndex
+CREATE INDEX "Tag_name_idx" ON "Tag"("name");
+
+-- CreateIndex
+CREATE INDEX "Tag_count_idx" ON "Tag"("count");
+
+-- CreateIndex
+CREATE INDEX "TrackTag_tagId_idx" ON "TrackTag"("tagId");
+
+-- AddForeignKey
+ALTER TABLE "TrackTag" ADD CONSTRAINT "TrackTag_trackId_fkey" FOREIGN KEY ("trackId") REFERENCES "Track"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TrackTag" ADD CONSTRAINT "TrackTag_tagId_fkey" FOREIGN KEY ("tagId") REFERENCES "Tag"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -241,6 +241,7 @@ model Track {
   persons             Json?
   SystemPlaylistTrack SystemPlaylistTrack[]
   Feed                Feed                  @relation(fields: [feedId], references: [id], onDelete: Cascade)
+  tags                TrackTag[]
 
   @@index([album])
   @@index([artist, album])
@@ -296,4 +297,29 @@ model UserPlaylist {
 
   @@index([createdBy])
   @@index([isPublic])
+}
+
+model Tag {
+  id        Int        @id @default(autoincrement())
+  name      String     @unique
+  count     Int        @default(0)
+  source    String     @default("v4vmusic")
+  createdAt DateTime   @default(now())
+  updatedAt DateTime
+  tracks    TrackTag[]
+
+  @@index([name])
+  @@index([count])
+}
+
+model TrackTag {
+  trackId   String
+  tagId     Int
+  source    String   @default("v4vmusic")
+  createdAt DateTime @default(now())
+  Track     Track    @relation(fields: [trackId], references: [id], onDelete: Cascade)
+  Tag       Tag      @relation(fields: [tagId], references: [id], onDelete: Cascade)
+
+  @@id([trackId, tagId])
+  @@index([tagId])
 }

--- a/scripts/ingest-v4v-tags.ts
+++ b/scripts/ingest-v4v-tags.ts
@@ -1,0 +1,31 @@
+/**
+ * Ingest crowd-sourced track tags from v4vmusic.com.
+ *
+ * V4V Music keys items by (feedGuid, itemGuid), which exactly matches our
+ * (Feed.guid, Track.guid). Items with no matching DB row are silently skipped.
+ *
+ * Usage:
+ *   npx tsx scripts/ingest-v4v-tags.ts
+ *   npx tsx scripts/ingest-v4v-tags.ts --limit=100
+ *
+ * Read-only against v4vmusic — no API key required (anonymous = 100 req/hr).
+ */
+
+import { ingestV4vTags } from '../lib/v4v-tags-ingest';
+import { prisma } from '../lib/prisma';
+
+const limit = parseInt(process.env.V4V_TAG_LIMIT || process.argv.find(a => a.startsWith('--limit='))?.split('=')[1] || '200');
+
+async function main() {
+  console.log(`Starting v4v tag ingest (limit=${limit})…`);
+  const result = await ingestV4vTags({ limit, logger: (msg) => console.log(`  ${msg}`) });
+  console.log(
+    `Done in ${(result.durationMs / 1000).toFixed(1)}s. ` +
+    `${result.tagsFetched} tags, ${result.itemsProcessed} items processed, ` +
+    `${result.tracksMatched} matched, ${result.itemsSkipped} skipped.`
+  );
+}
+
+main()
+  .catch((err) => { console.error(err); process.exit(1); })
+  .finally(() => prisma.$disconnect());


### PR DESCRIPTION
Two independent filter dropdowns slot into the top pill row:

- Genre — reads Feed.podcastCategories (~125 live entries); HTML entities
  decoded and junk values ("null"/"undefined"/"-") filtered out. Only counts
  categories on active non-podcast/publisher feeds so the dropdown matches
  what the grid actually surfaces.

- V4V Music Tag — mirrors crowd-sourced tags from v4vmusic.com into new
  Tag + TrackTag tables keyed by (Feed.guid, Track.guid). Only counts
  TrackTag rows whose parent Feed is active. Gated by V4V_TAGS_ENABLED
  env until the migration is applied everywhere.

Both are wired into /api/albums-fast as ?genre= and ?tag= query params;
mutually exclusive at the UI level. Album detail pages render a union
of per-track #tag chips linking back to the grid filter.

Ingest infrastructure:
- lib/v4v-tags-ingest.ts — core logic (parallel batch=3, 90s per-fetch
  timeout to accommodate v4vmusic's slow /items/bytag responses)
- scripts/ingest-v4v-tags.ts — CLI for ad-hoc runs
- /api/cron/ingest-v4v-tags — route hit by nightly workflow Step 7

Shared helpers extracted during development:
- components/FilterDropdown + useFilterDropdown — dropdown UI + state
- ALBUMS_FAST_TRACK_SELECT constant closes the two-parallel-Track-selects
  gotcha called out in CLAUDE.md (L160)
- lib/flags.ts — single source for isV4VTagsEnabled()

Also lands:
- /api/admin/cleanup-feeds — bulk-prune legacy Wavlake feeds with no
  tracks/publisher (ported from the abandoned feature/genre-filter branch)

Migration 20260422000000_add_v4v_tags adds the two new tables.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>