### PR TITLE
feat(home): "New" top-level filter — recently added music

### DIFF
--- a/app/api/albums-fast/route.ts
+++ b/app/api/albums-fast/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { Track } from '@prisma/client';
 import { getPlaylistUrls, getAllPlaylistIds } from '@/lib/playlist/configs';
-import { getBlacklistedFeedIds, BLACKLISTED_FEED_URLS } from '@/lib/feed-exclusions';
+import { getBlacklistedFeedIds, BLACKLISTED_FEED_URLS, isBowlAfterBowlPodcastEntry } from '@/lib/feed-exclusions';
 import {
   CACHE_DURATION,
   PLAYLIST_CACHE_DURATION,
@@ -302,29 +302,19 @@ export async function GET(request: Request) {
       trackCount: feed._count.Track
     }));
     
-    // Filter out Bowl After Bowl main podcast content but keep music covers
+    // Filter out Bowl After Bowl podcast (mis-imported as type='album') but keep
+    // Bowl Covers (legit music). Shared helper keeps /api/feeds/recent in sync.
     const podcastFilteredAlbums = albums.filter(album => {
-      const albumTitle = album.title?.toLowerCase() || '';
-      const albumArtist = album.artist?.toLowerCase() || '';
-      const feedUrl = album.feedUrl?.toLowerCase() || '';
-
-      // Keep Bowl Covers - these are legitimate music content
-      if (album.id === 'bowl-covers' || albumTitle.includes('bowl covers')) {
-        return true;
-      }
-
-      // Filter out main Bowl After Bowl podcast episodes
-      const isBowlAfterBowlPodcast = (
-        (albumTitle.includes('bowl after bowl') && !albumTitle.includes('covers')) ||
-        (albumArtist.includes('bowl after bowl') && !albumTitle.includes('covers')) ||
-        (feedUrl.includes('bowlafterbowl.com') && !albumTitle.includes('covers') && album.id !== 'bowl-covers')
-      );
-
-      if (isBowlAfterBowlPodcast && process.env.NODE_ENV === 'development') {
+      const isBab = isBowlAfterBowlPodcastEntry({
+        id: album.id,
+        title: album.title,
+        artist: album.artist,
+        feedUrl: album.feedUrl,
+      });
+      if (isBab && process.env.NODE_ENV === 'development') {
         console.log(`🚫 Filtering out Bowl After Bowl podcast: ${album.title} by ${album.artist}`);
       }
-
-      return !isBowlAfterBowlPodcast;
+      return !isBab;
     });
 
     // Filter out unresolved feed GUID placeholders - these have no usable data

--- a/app/api/feeds/recent/route.ts
+++ b/app/api/feeds/recent/route.ts
@@ -1,85 +1,93 @@
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getPlaylistUrls, getAllPlaylistIds } from '@/lib/playlist/configs';
-import { getBlacklistedFeedIds, BLACKLISTED_FEED_URLS } from '@/lib/feed-exclusions';
+import {
+  getBlacklistedFeedIds,
+  BLACKLISTED_FEED_URLS,
+  isPlaylistSourceFeedUrl,
+  isBowlAfterBowlPodcastEntry,
+} from '@/lib/feed-exclusions';
 
-// Feeds ranked by MAX(latest Track.createdAt, Feed.createdAt) — surfaces both
-// brand-new feed mints and feeds that just got new tracks (e.g., a podcast
-// publishing a new episode). Used by the home page's "New" section.
+// "New" = recently added to the app, ordered by Feed.createdAt desc. NOT release
+// date (oldestItemPubdate) and NOT track activity — re-using an old album just
+// because tracks updated would surface "Lost Cause"-style false-positives that
+// were already in the catalog. createdAt is when the feed record was minted.
 //
-// Includes both type='album' and type='podcast' rows: the whole point of using
-// the track-createdAt signal is catching new episodes on long-running podcast
-// feeds, which the main /api/albums-fast 'all' view filters out by design.
+// Music-only: type='album' feeds. Podcasts excluded entirely (including music-
+// podcasts like Homegrown Hits, Two For Tunestr, MMM, BAB) — users browse those
+// via the Podcasts filter or playlist pages.
 //
-// 3-query plan keeps the dataset traversal light: aggregate once, sort lightweight
-// rows, then heavily fetch only the top N. Computing MAX from a feed.Track[] capped
-// at 20 (albums-fast pattern) is wrong here — that select orders trackOrder asc,
-// so newest tracks on long feeds fall outside the window.
+// Three exclusion layers:
+//   1. type='album' query filter — drops correctly-typed podcasts.
+//   2. PLAYLIST_SOURCE_FEED_URLS — drops curated-playlist source podcasts (HGH,
+//      MMM, etc.) still mis-typed as 'album' in the DB.
+//   3. isBowlAfterBowlPodcastEntry — drops the BAB feed (mis-imported as 'album')
+//      while keeping Bowl Covers (legit music).
+//
+// Pagination via `offset` so the client can infinite-scroll like other filters.
+// We fetch all eligible feeds' metadata once (cheap — id/createdAt/url/title/
+// artist for ~1.7k rows), filter post-hoc, sort, then heavily fetch only the
+// page slice. Filtering must happen post-fetch because the JS-only exclusion
+// rules (URL normalization, BAB title/artist matching) don't translate to
+// Prisma where-clauses.
 export async function GET(request: Request) {
   try {
     const { searchParams } = new URL(request.url);
-    const limit = Math.min(parseInt(searchParams.get('limit') || '12'), 50);
+    const limit = Math.min(parseInt(searchParams.get('limit') || '50'), 200);
+    const offset = Math.max(parseInt(searchParams.get('offset') || '0'), 0);
 
-    const [lightFeeds, trackAggs] = await Promise.all([
-      prisma.feed.findMany({
-        where: {
-          status: 'active',
-          type: { in: ['album', 'podcast'] },
-        },
-        select: {
-          id: true,
-          createdAt: true,
-          originalUrl: true,
-        },
-      }),
-      prisma.track.groupBy({
-        by: ['feedId'],
-        where: { status: 'active', audioUrl: { not: '' } },
-        _max: { createdAt: true },
-      }),
-    ]);
-
-    const lastTrackByFeed = new Map<string, number>(
-      trackAggs.map((r) => [
-        r.feedId,
-        r._max.createdAt ? r._max.createdAt.getTime() : 0,
-      ])
-    );
+    const lightFeeds = await prisma.feed.findMany({
+      where: {
+        status: 'active',
+        type: 'album',
+      },
+      select: {
+        id: true,
+        createdAt: true,
+        originalUrl: true,
+        title: true,
+        artist: true,
+      },
+      orderBy: { createdAt: 'desc' },
+    });
 
     const playlistUrls = new Set(getPlaylistUrls());
     const playlistIds = new Set(getAllPlaylistIds());
     const blacklistedIds = new Set(getBlacklistedFeedIds());
     const blacklistedUrls = new Set(BLACKLISTED_FEED_URLS);
 
-    const ranked = lightFeeds
-      .filter(
-        (f) =>
-          !playlistIds.has(f.id) &&
-          !blacklistedIds.has(f.id) &&
-          (!f.originalUrl || !playlistUrls.has(f.originalUrl)) &&
-          (!f.originalUrl || !blacklistedUrls.has(f.originalUrl))
-      )
-      .map((f) => ({
-        id: f.id,
-        sortKey: Math.max(
-          lastTrackByFeed.get(f.id) ?? 0,
-          new Date(f.createdAt).getTime()
-        ),
-      }))
-      .sort((a, b) => b.sortKey - a.sortKey)
-      .slice(0, limit);
+    // URL exact-match against the playlistUrls/blacklistedUrls Sets is good enough
+    // for those (PI API + admin paths produce stable URLs there). Playlist-source
+    // exclusion uses the normalized helper because curated podcast URLs were
+    // imported through varying paths and string-equality misses casing/trailing
+    // differences (caught Mutton, Mead & Music slipping through).
+    const eligible = lightFeeds.filter(
+      (f) =>
+        !playlistIds.has(f.id) &&
+        !blacklistedIds.has(f.id) &&
+        (!f.originalUrl || !playlistUrls.has(f.originalUrl)) &&
+        (!f.originalUrl || !blacklistedUrls.has(f.originalUrl)) &&
+        (!f.originalUrl || !isPlaylistSourceFeedUrl(f.originalUrl)) &&
+        !isBowlAfterBowlPodcastEntry({
+          id: f.id,
+          title: f.title,
+          artist: f.artist,
+          feedUrl: f.originalUrl,
+        })
+    );
 
-    if (ranked.length === 0) {
+    const total = eligible.length;
+    const pageIds = eligible.slice(offset, offset + limit).map((f) => f.id);
+
+    if (pageIds.length === 0) {
       return NextResponse.json(
-        { albums: [], count: 0 },
+        { albums: [], count: 0, total, hasMore: false },
         { headers: { 'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=120' } }
       );
     }
 
-    const topIds = ranked.map((r) => r.id);
-
     const fullFeeds = await prisma.feed.findMany({
-      where: { id: { in: topIds } },
+      where: { id: { in: pageIds } },
       select: {
         id: true,
         guid: true,
@@ -130,66 +138,53 @@ export async function GET(request: Request) {
 
     const feedById = new Map(fullFeeds.map((f) => [f.id, f]));
 
-    const albums = ranked
-      .map((r) => feedById.get(r.id))
+    const albums = pageIds
+      .map((id) => feedById.get(id))
       .filter((f): f is NonNullable<typeof f> => Boolean(f))
-      .map((feed) => {
-        const isPodcast = feed.type === 'podcast';
-        // Podcasts: episodes newest-first (matches /api/albums-fast podcasts path).
-        const sortedTracks = isPodcast
-          ? [...feed.Track].sort((a, b) => {
-              const da = a.publishedAt ? new Date(a.publishedAt).getTime() : 0;
-              const db = b.publishedAt ? new Date(b.publishedAt).getTime() : 0;
-              return db - da;
-            })
-          : feed.Track;
-        return {
-          id: feed.id,
-          title: feed.title,
-          type: feed.type || 'album',
-          ...(isPodcast ? { isPodcast: true } : {}),
-          artist: feed.artist || feed.title,
-          description: feed.description || '',
-          coverArt: feed.image || '',
-          releaseDate: feed.oldestItemPubdate || feed.createdAt,
-          dateAdded: feed.createdAt,
-          feedUrl: feed.originalUrl,
-          feedGuid: feed.guid || null,
-          feedId: feed.id,
-          remoteFeedGuid: feed.guid || null,
-          guid: feed.Track?.[0]?.guid || feed.id,
-          episodeGuid: feed.Track?.[0]?.guid || feed.id,
-          link: feed.originalUrl,
-          priority: feed.priority,
-          tracks: sortedTracks.map((track) => ({
-            id: track.id,
-            title: track.title,
-            duration: track.duration || 180,
-            url: track.audioUrl,
-            image: track.image,
-            publishedAt: track.publishedAt,
-            guid: track.guid,
-            v4vRecipient: track.v4vRecipient,
-            v4vValue: track.v4vValue,
-            startTime: track.startTime,
-            endTime: track.endTime,
-            mediaType: track.mediaType || 'audio',
-            alternateEnclosures: track.alternateEnclosures,
-            chaptersUrl: track.chaptersUrl || undefined,
-            chapters: track.chapters || undefined,
-            valueTimeSplits: track.valueTimeSplits || undefined,
-            persons: (track as { persons?: unknown }).persons || undefined,
-          })),
-          v4vRecipient: feed.v4vRecipient,
-          v4vValue: feed.v4vValue,
-          persons: (feed as { persons?: unknown }).persons || undefined,
-          trackCount: feed._count?.Track || 0,
-          ...(isPodcast ? { totalTracks: feed._count?.Track || 0 } : {}),
-        };
-      });
+      .map((feed) => ({
+        id: feed.id,
+        title: feed.title,
+        type: feed.type || 'album',
+        artist: feed.artist || feed.title,
+        description: feed.description || '',
+        coverArt: feed.image || '',
+        releaseDate: feed.oldestItemPubdate || feed.createdAt,
+        dateAdded: feed.createdAt,
+        feedUrl: feed.originalUrl,
+        feedGuid: feed.guid || null,
+        feedId: feed.id,
+        remoteFeedGuid: feed.guid || null,
+        guid: feed.Track?.[0]?.guid || feed.id,
+        episodeGuid: feed.Track?.[0]?.guid || feed.id,
+        link: feed.originalUrl,
+        priority: feed.priority,
+        tracks: feed.Track.map((track) => ({
+          id: track.id,
+          title: track.title,
+          duration: track.duration || 180,
+          url: track.audioUrl,
+          image: track.image,
+          publishedAt: track.publishedAt,
+          guid: track.guid,
+          v4vRecipient: track.v4vRecipient,
+          v4vValue: track.v4vValue,
+          startTime: track.startTime,
+          endTime: track.endTime,
+          mediaType: track.mediaType || 'audio',
+          alternateEnclosures: track.alternateEnclosures,
+          chaptersUrl: track.chaptersUrl || undefined,
+          chapters: track.chapters || undefined,
+          valueTimeSplits: track.valueTimeSplits || undefined,
+          persons: (track as { persons?: unknown }).persons || undefined,
+        })),
+        v4vRecipient: feed.v4vRecipient,
+        v4vValue: feed.v4vValue,
+        persons: (feed as { persons?: unknown }).persons || undefined,
+        trackCount: feed._count?.Track || 0,
+      }));
 
     return NextResponse.json(
-      { albums, count: albums.length },
+      { albums, count: albums.length, total, hasMore: offset + albums.length < total },
       {
         headers: {
           'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=120',
@@ -199,7 +194,7 @@ export async function GET(request: Request) {
   } catch (err) {
     console.error('Error in /api/feeds/recent:', err);
     return NextResponse.json(
-      { albums: [], count: 0, error: err instanceof Error ? err.message : 'Unknown error' },
+      { albums: [], count: 0, total: 0, hasMore: false, error: err instanceof Error ? err.message : 'Unknown error' },
       { status: 500 }
     );
   }

--- a/app/api/feeds/recent/route.ts
+++ b/app/api/feeds/recent/route.ts
@@ -1,0 +1,206 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getPlaylistUrls, getAllPlaylistIds } from '@/lib/playlist/configs';
+import { getBlacklistedFeedIds, BLACKLISTED_FEED_URLS } from '@/lib/feed-exclusions';
+
+// Feeds ranked by MAX(latest Track.createdAt, Feed.createdAt) — surfaces both
+// brand-new feed mints and feeds that just got new tracks (e.g., a podcast
+// publishing a new episode). Used by the home page's "New" section.
+//
+// Includes both type='album' and type='podcast' rows: the whole point of using
+// the track-createdAt signal is catching new episodes on long-running podcast
+// feeds, which the main /api/albums-fast 'all' view filters out by design.
+//
+// 3-query plan keeps the dataset traversal light: aggregate once, sort lightweight
+// rows, then heavily fetch only the top N. Computing MAX from a feed.Track[] capped
+// at 20 (albums-fast pattern) is wrong here — that select orders trackOrder asc,
+// so newest tracks on long feeds fall outside the window.
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const limit = Math.min(parseInt(searchParams.get('limit') || '12'), 50);
+
+    const [lightFeeds, trackAggs] = await Promise.all([
+      prisma.feed.findMany({
+        where: {
+          status: 'active',
+          type: { in: ['album', 'podcast'] },
+        },
+        select: {
+          id: true,
+          createdAt: true,
+          originalUrl: true,
+        },
+      }),
+      prisma.track.groupBy({
+        by: ['feedId'],
+        where: { status: 'active', audioUrl: { not: '' } },
+        _max: { createdAt: true },
+      }),
+    ]);
+
+    const lastTrackByFeed = new Map<string, number>(
+      trackAggs.map((r) => [
+        r.feedId,
+        r._max.createdAt ? r._max.createdAt.getTime() : 0,
+      ])
+    );
+
+    const playlistUrls = new Set(getPlaylistUrls());
+    const playlistIds = new Set(getAllPlaylistIds());
+    const blacklistedIds = new Set(getBlacklistedFeedIds());
+    const blacklistedUrls = new Set(BLACKLISTED_FEED_URLS);
+
+    const ranked = lightFeeds
+      .filter(
+        (f) =>
+          !playlistIds.has(f.id) &&
+          !blacklistedIds.has(f.id) &&
+          (!f.originalUrl || !playlistUrls.has(f.originalUrl)) &&
+          (!f.originalUrl || !blacklistedUrls.has(f.originalUrl))
+      )
+      .map((f) => ({
+        id: f.id,
+        sortKey: Math.max(
+          lastTrackByFeed.get(f.id) ?? 0,
+          new Date(f.createdAt).getTime()
+        ),
+      }))
+      .sort((a, b) => b.sortKey - a.sortKey)
+      .slice(0, limit);
+
+    if (ranked.length === 0) {
+      return NextResponse.json(
+        { albums: [], count: 0 },
+        { headers: { 'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=120' } }
+      );
+    }
+
+    const topIds = ranked.map((r) => r.id);
+
+    const fullFeeds = await prisma.feed.findMany({
+      where: { id: { in: topIds } },
+      select: {
+        id: true,
+        guid: true,
+        title: true,
+        description: true,
+        originalUrl: true,
+        type: true,
+        artist: true,
+        image: true,
+        priority: true,
+        createdAt: true,
+        oldestItemPubdate: true,
+        v4vRecipient: true,
+        v4vValue: true,
+        persons: true,
+        Track: {
+          where: { audioUrl: { not: '' }, status: 'active' },
+          select: {
+            id: true,
+            guid: true,
+            title: true,
+            duration: true,
+            audioUrl: true,
+            image: true,
+            publishedAt: true,
+            v4vRecipient: true,
+            v4vValue: true,
+            startTime: true,
+            endTime: true,
+            trackOrder: true,
+            mediaType: true,
+            alternateEnclosures: true,
+            chaptersUrl: true,
+            chapters: true,
+            valueTimeSplits: true,
+            persons: true,
+          },
+          orderBy: [
+            { trackOrder: 'asc' },
+            { publishedAt: 'asc' },
+            { createdAt: 'asc' },
+          ],
+          take: 20,
+        },
+        _count: { select: { Track: { where: { status: 'active' } } } },
+      },
+    });
+
+    const feedById = new Map(fullFeeds.map((f) => [f.id, f]));
+
+    const albums = ranked
+      .map((r) => feedById.get(r.id))
+      .filter((f): f is NonNullable<typeof f> => Boolean(f))
+      .map((feed) => {
+        const isPodcast = feed.type === 'podcast';
+        // Podcasts: episodes newest-first (matches /api/albums-fast podcasts path).
+        const sortedTracks = isPodcast
+          ? [...feed.Track].sort((a, b) => {
+              const da = a.publishedAt ? new Date(a.publishedAt).getTime() : 0;
+              const db = b.publishedAt ? new Date(b.publishedAt).getTime() : 0;
+              return db - da;
+            })
+          : feed.Track;
+        return {
+          id: feed.id,
+          title: feed.title,
+          type: feed.type || 'album',
+          ...(isPodcast ? { isPodcast: true } : {}),
+          artist: feed.artist || feed.title,
+          description: feed.description || '',
+          coverArt: feed.image || '',
+          releaseDate: feed.oldestItemPubdate || feed.createdAt,
+          dateAdded: feed.createdAt,
+          feedUrl: feed.originalUrl,
+          feedGuid: feed.guid || null,
+          feedId: feed.id,
+          remoteFeedGuid: feed.guid || null,
+          guid: feed.Track?.[0]?.guid || feed.id,
+          episodeGuid: feed.Track?.[0]?.guid || feed.id,
+          link: feed.originalUrl,
+          priority: feed.priority,
+          tracks: sortedTracks.map((track) => ({
+            id: track.id,
+            title: track.title,
+            duration: track.duration || 180,
+            url: track.audioUrl,
+            image: track.image,
+            publishedAt: track.publishedAt,
+            guid: track.guid,
+            v4vRecipient: track.v4vRecipient,
+            v4vValue: track.v4vValue,
+            startTime: track.startTime,
+            endTime: track.endTime,
+            mediaType: track.mediaType || 'audio',
+            alternateEnclosures: track.alternateEnclosures,
+            chaptersUrl: track.chaptersUrl || undefined,
+            chapters: track.chapters || undefined,
+            valueTimeSplits: track.valueTimeSplits || undefined,
+            persons: (track as { persons?: unknown }).persons || undefined,
+          })),
+          v4vRecipient: feed.v4vRecipient,
+          v4vValue: feed.v4vValue,
+          persons: (feed as { persons?: unknown }).persons || undefined,
+          trackCount: feed._count?.Track || 0,
+          ...(isPodcast ? { totalTracks: feed._count?.Track || 0 } : {}),
+        };
+      });
+
+    return NextResponse.json(
+      { albums, count: albums.length },
+      {
+        headers: {
+          'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=120',
+        },
+      }
+    );
+  } catch (err) {
+    console.error('Error in /api/feeds/recent:', err);
+    return NextResponse.json(
+      { albums: [], count: 0, error: err instanceof Error ? err.message : 'Unknown error' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -137,7 +137,6 @@ function HomePageContent() {
   // Progressive loading states
   const [criticalAlbums, setCriticalAlbums] = useState<RSSAlbum[]>([]);
   const [enhancedAlbums, setEnhancedAlbums] = useState<RSSAlbum[]>([]);
-  const [recentlyAddedAlbums, setRecentlyAddedAlbums] = useState<RSSAlbum[]>([]);
   const [isCriticalLoaded, setIsCriticalLoaded] = useState(false);
   const [isEnhancedLoaded, setIsEnhancedLoaded] = useState(false);
   const [publisherStats, setPublisherStats] = useState<{ name: string; feedGuid: string; albumCount: number }[]>([]);
@@ -154,6 +153,8 @@ function HomePageContent() {
   const [displayedAlbums, setDisplayedAlbums] = useState<RSSAlbum[]>([]);
   const [hasMoreAlbums, setHasMoreAlbums] = useState(true);
   const ALBUMS_PER_PAGE = 50; // Load 50 albums per page for better user experience
+  const NEW_FILTER_PAGE_SIZE = 200; // 'new' shows a wider first cohort so historical re-imports roll off faster
+  const pageSizeForFilter = (filter: string) => (filter === 'new' ? NEW_FILTER_PAGE_SIZE : ALBUMS_PER_PAGE);
 
   // Format-aware loading state (for "all" filter - load all albums before EPs)
   const [formatCounts, setFormatCounts] = useState<{ albums: number; eps: number; singles: number } | null>(null);
@@ -173,7 +174,7 @@ function HomePageContent() {
   const [backgroundImageLoaded, setBackgroundImageLoaded] = useState(false);
 
   // Controls state - Initialize from URL params (works on both server and client)
-  const validFilters: FilterType[] = ['all', 'albums', 'eps', 'singles', 'publishers', 'playlist', 'podcasts', 'videos'];
+  const validFilters: FilterType[] = ['all', 'new', 'albums', 'eps', 'singles', 'publishers', 'playlist', 'podcasts', 'videos'];
   const urlFilter = searchParams?.get('filter');
   const initialFilter = (urlFilter && validFilters.includes(urlFilter as FilterType))
     ? (urlFilter as FilterType)
@@ -330,28 +331,6 @@ function HomePageContent() {
 
   // Audio playback is now handled by the global AudioContext
 
-  // Fetch the 12 newest feeds for the "New" home section. Server ranks by
-  // MAX(latest Track.createdAt, Feed.createdAt) so a podcast that just got a new
-  // episode ranks alongside a brand-new album. Lives on a dedicated endpoint
-  // because /api/albums-fast?filter=all strips type='podcast' rows.
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      try {
-        const res = await fetch('/api/feeds/recent?limit=12');
-        if (!res.ok) return;
-        const data = await res.json();
-        if (cancelled) return;
-        setRecentlyAddedAlbums((data.albums || []).slice(0, 12));
-      } catch (err) {
-        if (process.env.NODE_ENV === 'development') {
-          console.warn('Failed to load recent feeds:', err);
-        }
-      }
-    })();
-    return () => { cancelled = true; };
-  }, []);
-
   useEffect(() => {
     // Prevent multiple loads
     if (hasLoadedRef.current) {
@@ -442,8 +421,9 @@ function HomePageContent() {
 
       // OPTIMIZED: Load albums in single API call (includes totalCount in response)
       // Removed redundant count query - totalCount is now included in albums response
-      const startIndex = (currentPage - 1) * ALBUMS_PER_PAGE;
-      const { albums: pageAlbums, totalCount } = await loadAlbumsData('all', ALBUMS_PER_PAGE, startIndex, activeFilter);
+      const pageSize = pageSizeForFilter(activeFilter);
+      const startIndex = (currentPage - 1) * pageSize;
+      const { albums: pageAlbums, totalCount } = await loadAlbumsData('all', pageSize, startIndex, activeFilter);
       
       // Update total albums count from API response (for pagination)
       setTotalAlbums(totalCount);
@@ -455,9 +435,10 @@ function HomePageContent() {
       setDisplayedAlbums(pageAlbums);
       setAlbums(pageAlbums); // Also set the main albums state
       
-      // Use totalCount to correctly determine if there are more albums
-      // If we got a full page (50 albums) and there's more than what we loaded, there are more
-      setHasMoreAlbums(pageAlbums.length >= ALBUMS_PER_PAGE && pageAlbums.length < totalCount);
+      // Use totalCount to correctly determine if there are more albums.
+      // If we got a full page (page size varies by filter) and there's more than what we
+      // loaded, there are more.
+      setHasMoreAlbums(pageAlbums.length >= pageSize && pageAlbums.length < totalCount);
       setIsCriticalLoaded(true);
       setIsEnhancedLoaded(true);
       setLoadingProgress(100);
@@ -511,8 +492,13 @@ function HomePageContent() {
       try {
         // Format-aware loading: For "all" filter, ensure we load all albums before any EPs
         const currentCount = displayedAlbums.length;
-        let startIndex = (nextPage - 1) * ALBUMS_PER_PAGE;
-        let loadLimit = ALBUMS_PER_PAGE;
+        const pageSize = pageSizeForFilter(activeFilter);
+        // 'new' uses a wider page size than other filters (see NEW_FILTER_PAGE_SIZE).
+        // Compute startIndex from the actual loaded count rather than `(nextPage - 1) *
+        // pageSize` so the first→subsequent page transition stays correct under non-
+        // uniform page sizes.
+        let startIndex = activeFilter === 'new' ? currentCount : (nextPage - 1) * pageSize;
+        let loadLimit = pageSize;
 
         // When "all" is selected and we have format counts, enforce format boundaries
         if (activeFilter === 'all' && formatCounts) {
@@ -732,7 +718,7 @@ function HomePageContent() {
         };
       } else {
         // Single fetch - loadAlbumsData already returns totalCount
-        const { albums: pageAlbums, totalCount } = await loadAlbumsData('all', ALBUMS_PER_PAGE, 0, newFilter);
+        const { albums: pageAlbums, totalCount } = await loadAlbumsData('all', pageSizeForFilter(newFilter), 0, newFilter);
 
         resultData = {
           albums: pageAlbums,
@@ -784,6 +770,18 @@ function HomePageContent() {
           console.log(`⚠️ loadAlbumsData called with ${filter} filter - this should be handled by handleFilterChange`);
         }
         return { albums: [], totalCount: 0 }; // Return empty array to prevent showing wrong data
+      }
+
+      // 'new' uses /api/feeds/recent — music-only feeds ordered by Feed.createdAt desc
+      // (when added to the app). Server preserves rank order across pages via offset; do
+      // not apply client-side sortType.
+      if (filter === 'new') {
+        const response = await fetch(`/api/feeds/recent?limit=${limit}&offset=${offset}`);
+        if (!response.ok) {
+          throw new Error(`/api/feeds/recent failed: ${response.status}`);
+        }
+        const data = await response.json();
+        return { albums: data.albums || [], totalCount: data.total || 0 };
       }
 
       // Handle playlist filter separately - use fast endpoint for better performance
@@ -1524,6 +1522,7 @@ function HomePageContent() {
                 className="md:hidden bg-gray-800 text-white px-3 py-2 rounded text-sm border border-gray-600 focus:outline-none focus:border-stablekraft-teal"
               >
                 <option value="all">All</option>
+                <option value="new">New</option>
                 <option value="albums">Albums</option>
                 <option value="eps">EPs</option>
                 <option value="singles">Singles</option>
@@ -1537,6 +1536,7 @@ function HomePageContent() {
               <div className="hidden md:flex gap-1">
                 {[
                   { value: 'all', label: 'All' },
+                  { value: 'new', label: 'New' },
                   { value: 'albums', label: 'Albums' },
                   { value: 'eps', label: 'EPs' },
                   { value: 'singles', label: 'Singles' },
@@ -1656,7 +1656,7 @@ function HomePageContent() {
                 Retry
               </button>
             </div>
-          ) : filteredAlbums.length > 0 ? (
+          ) : filteredAlbums.length > 0 || activeFilter === 'new' ? (
             <div className="max-w-7xl mx-auto">
               
 
@@ -1674,7 +1674,8 @@ function HomePageContent() {
                 </div>
               )}
 
-              {/* Controls Bar - Sort only (other controls in main menu); options vary by filter */}
+              {/* Controls Bar - Sort only (other controls in main menu); options vary by filter.
+                  'new' opts out — server ranks by max-track-or-feed createdAt, client sort wouldn't apply. */}
               {(activeFilter === 'all' || activeFilter === 'albums' || activeFilter === 'eps' || activeFilter === 'singles' || activeFilter === 'publishers' || activeFilter === 'playlist' || activeFilter === 'podcasts') && (
                 <ControlsBar
                   activeFilter={activeFilter}
@@ -1717,25 +1718,26 @@ function HomePageContent() {
                     </div>
                   </div>
                 </div>
+              ) : activeFilter === 'new' ? (
+                // 'New' filter — music-only feeds ordered by Feed.createdAt desc, paginated
+                // via /api/feeds/recent. Render in server order (no client sort) so pages
+                // stitch together correctly as infinite scroll fetches them.
+                filteredAlbums.length > 0 ? (
+                  <div className="grid grid-cols-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-4 gap-3 sm:gap-4 md:gap-6">
+                    {filteredAlbums.map((album) => (
+                      <AlbumCard
+                        key={`new-${album.feedId || album.feedGuid || album.title}`}
+                        album={album}
+                        onPlay={playAlbum}
+                      />
+                    ))}
+                  </div>
+                ) : (
+                  <SkeletonGrid count={12} />
+                )
               ) : activeFilter === 'all' ? (
                 // Original sectioned layout for "All" filter
                 <>
-                  {/* New — newest 12 feeds by MAX(latest track createdAt, feed createdAt) */}
-                  {recentlyAddedAlbums.length > 0 && (
-                    <div className="mb-12">
-                      <h2 className="text-2xl font-bold mb-6 text-white">New</h2>
-                      <div className="grid grid-cols-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-4 gap-3 sm:gap-4 md:gap-6">
-                        {recentlyAddedAlbums.map((album) => (
-                          <AlbumCard
-                            key={`recent-${album.feedId || album.feedGuid || album.title}`}
-                            album={album}
-                            onPlay={playAlbum}
-                          />
-                        ))}
-                      </div>
-                    </div>
-                  )}
-
                   {/* Albums Grid */}
                   {albumsWithMultipleTracks.length > 0 && (
                       <div className="mb-12">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -137,6 +137,7 @@ function HomePageContent() {
   // Progressive loading states
   const [criticalAlbums, setCriticalAlbums] = useState<RSSAlbum[]>([]);
   const [enhancedAlbums, setEnhancedAlbums] = useState<RSSAlbum[]>([]);
+  const [recentlyAddedAlbums, setRecentlyAddedAlbums] = useState<RSSAlbum[]>([]);
   const [isCriticalLoaded, setIsCriticalLoaded] = useState(false);
   const [isEnhancedLoaded, setIsEnhancedLoaded] = useState(false);
   const [publisherStats, setPublisherStats] = useState<{ name: string; feedGuid: string; albumCount: number }[]>([]);
@@ -328,7 +329,28 @@ function HomePageContent() {
 
 
   // Audio playback is now handled by the global AudioContext
-  
+
+  // Fetch the 12 most recently added feeds for the "Recently Added" home section.
+  // Independent of the main grid (which is name-asc by default), so we always have
+  // the true newest items even when they fall outside the first alphabetical page.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch('/api/albums-fast?limit=12&sort=added-desc&filter=all');
+        if (!res.ok) return;
+        const data = await res.json();
+        if (cancelled) return;
+        setRecentlyAddedAlbums((data.albums || []).slice(0, 12));
+      } catch (err) {
+        if (process.env.NODE_ENV === 'development') {
+          console.warn('Failed to load recently added albums:', err);
+        }
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
   useEffect(() => {
     // Prevent multiple loads
     if (hasLoadedRef.current) {
@@ -1697,6 +1719,22 @@ function HomePageContent() {
               ) : activeFilter === 'all' ? (
                 // Original sectioned layout for "All" filter
                 <>
+                  {/* Recently Added — newest 12 feeds, fetched independently of the main grid */}
+                  {recentlyAddedAlbums.length > 0 && (
+                    <div className="mb-12">
+                      <h2 className="text-2xl font-bold mb-6 text-white">Recently Added</h2>
+                      <div className="grid grid-cols-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-4 gap-3 sm:gap-4 md:gap-6">
+                        {recentlyAddedAlbums.map((album) => (
+                          <AlbumCard
+                            key={`recent-${album.feedId || album.feedGuid || album.title}`}
+                            album={album}
+                            onPlay={playAlbum}
+                          />
+                        ))}
+                      </div>
+                    </div>
+                  )}
+
                   {/* Albums Grid */}
                   {albumsWithMultipleTracks.length > 0 && (
                       <div className="mb-12">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -330,21 +330,22 @@ function HomePageContent() {
 
   // Audio playback is now handled by the global AudioContext
 
-  // Fetch the 12 most recently added feeds for the "Recently Added" home section.
-  // Independent of the main grid (which is name-asc by default), so we always have
-  // the true newest items even when they fall outside the first alphabetical page.
+  // Fetch the 12 newest feeds for the "New" home section. Server ranks by
+  // MAX(latest Track.createdAt, Feed.createdAt) so a podcast that just got a new
+  // episode ranks alongside a brand-new album. Lives on a dedicated endpoint
+  // because /api/albums-fast?filter=all strips type='podcast' rows.
   useEffect(() => {
     let cancelled = false;
     (async () => {
       try {
-        const res = await fetch('/api/albums-fast?limit=12&sort=added-desc&filter=all');
+        const res = await fetch('/api/feeds/recent?limit=12');
         if (!res.ok) return;
         const data = await res.json();
         if (cancelled) return;
         setRecentlyAddedAlbums((data.albums || []).slice(0, 12));
       } catch (err) {
         if (process.env.NODE_ENV === 'development') {
-          console.warn('Failed to load recently added albums:', err);
+          console.warn('Failed to load recent feeds:', err);
         }
       }
     })();
@@ -1719,10 +1720,10 @@ function HomePageContent() {
               ) : activeFilter === 'all' ? (
                 // Original sectioned layout for "All" filter
                 <>
-                  {/* Recently Added — newest 12 feeds, fetched independently of the main grid */}
+                  {/* New — newest 12 feeds by MAX(latest track createdAt, feed createdAt) */}
                   {recentlyAddedAlbums.length > 0 && (
                     <div className="mb-12">
-                      <h2 className="text-2xl font-bold mb-6 text-white">Recently Added</h2>
+                      <h2 className="text-2xl font-bold mb-6 text-white">New</h2>
                       <div className="grid grid-cols-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-4 gap-3 sm:gap-4 md:gap-6">
                         {recentlyAddedAlbums.map((album) => (
                           <AlbumCard

--- a/components/ControlsBar.tsx
+++ b/components/ControlsBar.tsx
@@ -2,7 +2,7 @@
 
 import { Filter, Grid3X3, List, Shuffle } from 'lucide-react';
 
-export type FilterType = 'all' | 'albums' | 'eps' | 'singles' | 'publishers' | 'playlist' | 'videos' | 'podcasts';
+export type FilterType = 'all' | 'new' | 'albums' | 'eps' | 'singles' | 'publishers' | 'playlist' | 'videos' | 'podcasts';
 export type ViewType = 'grid' | 'list';
 export type SortType = 'name-asc' | 'name-desc' | 'year-desc' | 'year-asc' | 'tracks-desc' | 'tracks-asc' | 'added-desc' | 'added-asc';
 
@@ -68,6 +68,7 @@ const defaultSortOptions = SORT_OPTIONS_ALBUMS;
 // Filter options for publishers
 const defaultFilters: { value: FilterType; label: string }[] = [
   { value: 'all', label: 'All' },
+  { value: 'new', label: 'New' },
   { value: 'albums', label: 'Albums' },
   { value: 'eps', label: 'EPs' },
   { value: 'singles', label: 'Singles' },

--- a/lib/feed-exclusions.ts
+++ b/lib/feed-exclusions.ts
@@ -78,3 +78,30 @@ export function isPlaylistSourceFeedUrl(url: string): boolean {
 export function getBlacklistedFeedIds(): string[] {
   return [...BLACKLISTED_FEED_IDS];
 }
+
+// Bowl After Bowl is a podcast feed mis-imported as type='album' (slug
+// /album/bowl-after-bowl) but its episodes are spoken-word podcast content.
+// "Bowl Covers" (a derived music feed) is legitimate music — keep it.
+// Used by both /api/albums-fast and /api/feeds/recent so the album grid
+// stays free of the podcast.
+export function isBowlAfterBowlPodcastEntry(entry: {
+  id?: string | null;
+  title?: string | null;
+  artist?: string | null;
+  feedUrl?: string | null;
+}): boolean {
+  const title = (entry.title || '').toLowerCase();
+  const artist = (entry.artist || '').toLowerCase();
+  const feedUrl = (entry.feedUrl || '').toLowerCase();
+
+  // Always keep Bowl Covers (legitimate music content).
+  if (entry.id === 'bowl-covers' || title.includes('bowl covers')) {
+    return false;
+  }
+
+  return (
+    (title.includes('bowl after bowl') && !title.includes('covers')) ||
+    (artist.includes('bowl after bowl') && !title.includes('covers')) ||
+    (feedUrl.includes('bowlafterbowl.com') && !title.includes('covers') && entry.id !== 'bowl-covers')
+  );
+}

--- a/lib/feed-exclusions.ts
+++ b/lib/feed-exclusions.ts
@@ -37,7 +37,8 @@ export const DUPLICATE_SOURCE_FEED_URLS = [
 // Only admin-initiated imports should populate these.
 export const PLAYLIST_SOURCE_FEED_URLS = [
   'https://music.behindthesch3m3s.com/b4ts%20feed/feed.xml',  // B4TS
-  'https://mmmusic-project.ams3.cdn.digitaloceanspaces.com/Mutton_Mead__Music/feed.xml',  // MMM
+  'https://mmmusic-project.ams3.cdn.digitaloceanspaces.com/Mutton_Mead__Music/feed.xml',  // MMM (legacy host)
+  'https://mmmusic.show/podcast/feed.xml',  // MMM (current host)
   'https://feed.homegrownhits.xyz/feed.xml',  // HGH
   'https://sirlibre.com/lightning-thrashes-rss.xml',  // LT
   'https://serve.podhome.fm/rss/3aebb7a8-5942-5ee7-a148-8bdc14f1f3d4',  // Upbeats


### PR DESCRIPTION
Adds a dedicated **"New"** filter (peer to All / Albums / EPs / Singles / Podcasts) that surfaces music albums recently added to the app, ordered by `Feed.createdAt desc`. Replaces the abandoned in-PR design that put a 12-card section on the "All" view.

## What it shows

- **Music only** — `type='album'` feeds. Three exclusion layers drop podcasts that slip through:
  1. DB type filter rejects correctly-typed `type='podcast'` rows.
  2. `PLAYLIST_SOURCE_FEED_URLS` rejects curated-playlist source podcasts (HGH, MMM, Two For Tunestr) still mis-typed as `'album'`.
  3. `isBowlAfterBowlPodcastEntry()` rejects the BAB feed (mis-imported as `'album'`) while keeping Bowl Covers (legit music).
- **Recently added to the app**, not new releases — sort key is `Feed.createdAt desc`. Re-using an old album because its tracks updated would surface false-positives that were already in the catalog.
- **Infinite scroll** with a 200-card page size (other filters stay at 50) so the historical re-import noise rolls off the first page faster.

## Implementation

- New endpoint `/api/feeds/recent` — `feed.findMany` with `orderBy createdAt desc`, filter post-fetch (URL-normalized), slice for the page. Returns `total` + `hasMore`. 60s `s-maxage` Fastly cache.
- `pageSizeForFilter()` helper in `app/page.tsx` wires the larger page size into `loadCriticalAlbums`, `loadMoreAlbums`, and `handleFilterChange`. `loadMoreAlbums` derives the `'new'` offset from `displayedAlbums.length` so the first→subsequent page transition works under non-uniform page sizes.
- `ControlsBar` hides the sort dropdown on `'new'` — server controls rank order.
- Refactor: BAB filter extracted from inline 22-line block in `albums-fast/route.ts` into a shared helper. Same behavior, one source of truth.
- Exclusions: added current MMM self-host (`mmmusic.show`) alongside the legacy DigitalOcean URL.

## Commit history

1. `refactor(exclusions): extract isBowlAfterBowlPodcastEntry helper`
2. `chore(exclusions): add current MMM host to playlist sources`
3. `feat(home): promote "New" to top-level filter, music-only, paginated`

(plus the original 2 PR commits, which establish the iteration history — early designs ranked by `MAX(latest Track.createdAt, Feed.createdAt)` and showed the section on All; both were superseded.)

## Test plan

- [ ] `/?filter=new` renders 200 cards on first paint.
- [ ] No podcasts visible — verify Bowl After Bowl / Homegrown Hits / Two For Tunestr / MMM / UpBEATs are absent.
- [ ] Infinite scroll fetches the next 200 on demand.
- [ ] Filter persists across reload via `?filter=new` URL state.
- [ ] Other filters (All / Albums / EPs / Singles / Podcasts) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
