### PR TITLE
fix(exclusions): hard-blacklist Henrik Flyman Wavlake mirrors + plug mint gaps

### DIFF
--- a/app/api/admin/publishers/import-albums/route.ts
+++ b/app/api/admin/publishers/import-albums/route.ts
@@ -4,7 +4,7 @@ import { generatePodcastIndexHeaders } from '@/lib/podcast-index-api';
 import { getEpisodesFromAPI, parseDuration } from '@/lib/feed-parsing';
 import { calculateTrackOrder } from '@/lib/rss-parser-db';
 import { generateAlbumSlug, normalizeUrl } from '@/lib/url-utils';
-import { isAutoImportSuppressedUrl } from '@/lib/feed-exclusions';
+import { isBlacklistedFeedUrl } from '@/lib/feed-exclusions';
 
 const API_BASE_URL = 'https://api.podcastindex.org/api/1.0';
 
@@ -140,11 +140,10 @@ export async function POST(request: NextRequest) {
           const podcastGuid = piFeed.podcastGuid || '';
 
           try {
-            // Skip URLs explicitly suppressed from auto-import (blacklist or
-            // duplicate-source mirrors). Prevents the 4 AM cron from recreating
+            // Skip blacklisted URLs. Prevents the 4 AM cron from recreating
             // feed rows the user has intentionally deleted.
-            if (feedUrl && isAutoImportSuppressedUrl(feedUrl)) {
-              result.skippedDetails.push(`suppressed:${piFeed.title}|${feedUrl}`);
+            if (feedUrl && isBlacklistedFeedUrl(feedUrl)) {
+              result.skippedDetails.push(`blacklisted:${piFeed.title}|${feedUrl}`);
               result.skipped++;
               continue;
             }

--- a/app/api/feeds/route.ts
+++ b/app/api/feeds/route.ts
@@ -115,6 +115,14 @@ async function importMissingAlbums(
       continue;
     }
 
+    // Skip blacklisted URLs — a publisher feed listing them as remoteItems
+    // must not auto-mint album rows.
+    if (isBlacklistedFeedUrl(item.feedUrl)) {
+      console.log(`🚫 Skipping blacklisted album URL from publisher: ${item.feedUrl}`);
+      skipped++;
+      continue;
+    }
+
     try {
       // Check if album already exists by URL or GUID
       const conditions: any[] = [{ originalUrl: item.feedUrl }];
@@ -360,12 +368,31 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // Reject blacklisted URLs before any DB writes. The podping consumer's
+    // !exists && fromMsp branch can otherwise re-mint blacklisted feeds since
+    // /api/feeds/exists also returns false for them.
+    if (isBlacklistedFeedUrl(originalUrl)) {
+      return NextResponse.json(
+        { error: 'Feed URL is blacklisted', originalUrl },
+        { status: 403 }
+      );
+    }
+
     // Resolve Podcast Index web page URLs to actual RSS feed URLs
     let resolvedUrl = originalUrl;
     const piResolution = await resolvePodcastIndexUrl(originalUrl);
     if (piResolution) {
       resolvedUrl = piResolution.feedUrl;
       console.log(`🔄 Resolved Podcast Index URL → ${resolvedUrl}`);
+    }
+
+    // Re-check after PI resolution in case the canonical RSS URL is the
+    // blacklisted one even though the caller passed a podcastindex.org link.
+    if (resolvedUrl !== originalUrl && isBlacklistedFeedUrl(resolvedUrl)) {
+      return NextResponse.json(
+        { error: 'Feed URL is blacklisted', originalUrl: resolvedUrl },
+        { status: 403 }
+      );
     }
 
     const normalizedOriginalUrl = normalizeUrl(resolvedUrl);

--- a/lib/feed-exclusions.ts
+++ b/lib/feed-exclusions.ts
@@ -13,16 +13,11 @@ export const BLACKLISTED_FEED_IDS = [
 export const BLACKLISTED_FEED_URLS = [
   'https://zine.bitpunk.fm/feeds/unwound.xml',
   'https://zine.bitpunk.fm/feeds/bitpunk-fm.xml',
-];
-
-// Feed URLs that duplicate content already available at a canonical source
-// (e.g. Wavlake mirrors of albums the artist also publishes on their own site).
-// Suppressed from automated re-import paths (Step 5b `import-albums` + podping
-// auto-mint) but NOT hidden from the album grid — admin can still add them
-// manually via /admin if ever needed. Without this list, deleting the duplicate
-// just causes the next 4 AM cron to recreate it from PI API artist search.
-export const DUPLICATE_SOURCE_FEED_URLS = [
-  // Henrik Flyman — canonical feeds at henrikflyman.com
+  // Henrik Flyman pulled all his music off Wavlake and self-hosts at
+  // henrikflyman.com. Every Wavlake mirror is 404 upstream and must stay
+  // banned everywhere (album grid, search, /api/feeds/exists,
+  // process-remote-items, Step 5b auto-import) so the 4 AM cron can't
+  // re-mint them from PI API artist search.
   'https://wavlake.com/feed/music/9a5340e4-50ca-48c3-9b06-3f6b782b5131',  // A Song For The Voiceless
   'https://wavlake.com/feed/music/9a218bec-4411-4f93-9caa-f3f84e4ef5f0',  // Authority
   'https://wavlake.com/feed/music/26822e8f-cc32-4f7b-b760-720cbe2455ff',  // Thorns
@@ -48,7 +43,6 @@ export const PLAYLIST_SOURCE_FEED_URLS = [
 ];
 
 const normalizedBlacklistedUrls = BLACKLISTED_FEED_URLS.map(normalizeUrl);
-const normalizedDuplicateSourceUrls = DUPLICATE_SOURCE_FEED_URLS.map(normalizeUrl);
 const normalizedPlaylistSourceUrls = PLAYLIST_SOURCE_FEED_URLS.map(normalizeUrl);
 
 export function isBlacklistedFeedId(id: string): boolean {
@@ -58,17 +52,6 @@ export function isBlacklistedFeedId(id: string): boolean {
 export function isBlacklistedFeedUrl(url: string): boolean {
   const normalized = normalizeUrl(url);
   return normalizedBlacklistedUrls.includes(normalized);
-}
-
-export function isDuplicateSourceUrl(url: string): boolean {
-  const normalized = normalizeUrl(url);
-  return normalizedDuplicateSourceUrls.includes(normalized);
-}
-
-// Combined check for automated re-import paths (Step 5b, podping auto-mint).
-// Excludes both outright-banned URLs and duplicate-source mirrors.
-export function isAutoImportSuppressedUrl(url: string): boolean {
-  return isBlacklistedFeedUrl(url) || isDuplicateSourceUrl(url);
 }
 
 export function isPlaylistSourceFeedUrl(url: string): boolean {


### PR DESCRIPTION
Six Wavlake Flyman feeds were in DUPLICATE_SOURCE_FEED_URLS, which only
suppresses Step 5b auto-import — admin/podping mints still went through
and the album grid still rendered them, so they kept resurfacing
(/album/shadowbanned reappeared after a6f00c9 supposedly fixed it).

Move all six to BLACKLISTED_FEED_URLS so they are filtered everywhere
(album grid, search, /api/feeds/exists, process-remote-items). He pulled
his catalog off Wavlake entirely and self-hosts at henrikflyman.com — the
softer "duplicate source" semantics no longer apply.

Plug two mint gaps that bypassed the existing blacklist:

- POST /api/feeds had no URL-blacklist guard. The podping consumer's
  !exists && fromMsp branch hits this directly, and /api/feeds/exists
  returns false for blacklisted URLs, so the consumer treated them as
  brand-new feeds and re-minted them.
- importMissingAlbums() inside POST /api/feeds (publisher feed
  auto-import) walked remoteItems and created album rows with no
  blacklist check — a Wavlake artist publisher feed listing the six
  mirrors as remoteItems would re-create all of them.

Both now early-return / skip on isBlacklistedFeedUrl.

DUPLICATE_SOURCE_FEED_URLS, isDuplicateSourceUrl, and
isAutoImportSuppressedUrl are removed as the only remaining caller
(import-albums Step 5b) collapses to isBlacklistedFeedUrl.