### PR TITLE
feat(admin): music-show-only flag for publisher feeds

### DIFF
--- a/app/api/admin/music-show-only-publishers/route.ts
+++ b/app/api/admin/music-show-only-publishers/route.ts
@@ -1,0 +1,219 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { invalidateAlbumsFastCache } from '@/lib/caches/albums-fast-cache';
+import { invalidateSearchCache } from '@/lib/caches/search-cache';
+
+function invalidateFeedListCaches(): void {
+  invalidateAlbumsFastCache();
+  invalidateSearchCache();
+}
+
+// GET /api/admin/music-show-only-publishers
+// Lists every publisher feed with its current flag state and child counts.
+export async function GET() {
+  try {
+    const publishers = await prisma.feed.findMany({
+      where: { type: 'publisher' },
+      select: {
+        id: true,
+        title: true,
+        artist: true,
+        originalUrl: true,
+        image: true,
+        musicShowOnly: true,
+        _count: { select: { other_Feed: true } },
+      },
+      orderBy: [
+        { musicShowOnly: 'desc' },
+        { title: 'asc' },
+      ],
+    });
+
+    // Per-publisher track count across all child album feeds.
+    const trackCounts = await prisma.track.groupBy({
+      by: ['feedId'],
+      _count: { _all: true },
+      where: { Feed: { publisherId: { in: publishers.map(p => p.id) } } },
+    });
+    const childTracksByPublisher = new Map<string, number>();
+    if (trackCounts.length > 0) {
+      const childFeeds = await prisma.feed.findMany({
+        where: { id: { in: trackCounts.map(t => t.feedId) } },
+        select: { id: true, publisherId: true },
+      });
+      const publisherByChild = new Map(childFeeds.map(f => [f.id, f.publisherId]));
+      for (const t of trackCounts) {
+        const pubId = publisherByChild.get(t.feedId);
+        if (!pubId) continue;
+        childTracksByPublisher.set(pubId, (childTracksByPublisher.get(pubId) ?? 0) + t._count._all);
+      }
+    }
+
+    return NextResponse.json({
+      publishers: publishers.map(p => ({
+        id: p.id,
+        title: p.title,
+        artist: p.artist,
+        originalUrl: p.originalUrl,
+        image: p.image,
+        musicShowOnly: p.musicShowOnly,
+        childAlbums: p._count.other_Feed,
+        childTracks: childTracksByPublisher.get(p.id) ?? 0,
+      })),
+    });
+  } catch (error) {
+    console.error('Error listing music-show-only publishers:', error);
+    return NextResponse.json({ error: 'Failed to list publishers' }, { status: 500 });
+  }
+}
+
+// PATCH /api/admin/music-show-only-publishers
+// Body: { id: string, musicShowOnly: boolean }
+export async function PATCH(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { id, musicShowOnly } = body as { id?: string; musicShowOnly?: boolean };
+
+    if (!id || typeof musicShowOnly !== 'boolean') {
+      return NextResponse.json(
+        { error: 'Body must include { id: string, musicShowOnly: boolean }' },
+        { status: 400 }
+      );
+    }
+
+    const feed = await prisma.feed.findUnique({ where: { id }, select: { id: true, type: true } });
+    if (!feed) {
+      return NextResponse.json({ error: 'Feed not found' }, { status: 404 });
+    }
+    if (feed.type !== 'publisher') {
+      return NextResponse.json(
+        { error: 'Music-show-only flag is only valid on publisher feeds' },
+        { status: 400 }
+      );
+    }
+
+    const updated = await prisma.feed.update({
+      where: { id },
+      data: { musicShowOnly },
+      select: { id: true, title: true, musicShowOnly: true },
+    });
+
+    return NextResponse.json({ feed: updated });
+  } catch (error) {
+    console.error('Error updating music-show-only flag:', error);
+    return NextResponse.json({ error: 'Failed to update flag' }, { status: 500 });
+  }
+}
+
+// POST /api/admin/music-show-only-publishers
+// Body: { id: string, action: 'preview' | 'cleanup' }
+//
+// Inspects child album feeds belonging to this publisher and identifies any
+// whose tracks are NOT referenced by a SystemPlaylistTrack. Albums where ≥1
+// track has been played on a curated music show are kept in full.
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { id, action } = body as { id?: string; action?: 'preview' | 'cleanup' };
+
+    if (!id || (action !== 'preview' && action !== 'cleanup')) {
+      return NextResponse.json(
+        { error: 'Body must include { id: string, action: "preview" | "cleanup" }' },
+        { status: 400 }
+      );
+    }
+
+    const publisher = await prisma.feed.findUnique({
+      where: { id },
+      select: { id: true, type: true, title: true, musicShowOnly: true },
+    });
+    if (!publisher) {
+      return NextResponse.json({ error: 'Publisher not found' }, { status: 404 });
+    }
+    if (publisher.type !== 'publisher') {
+      return NextResponse.json(
+        { error: 'Cleanup only runs on publisher feeds' },
+        { status: 400 }
+      );
+    }
+
+    // Find all child album feeds (publisherId points at this publisher).
+    const childFeeds = await prisma.feed.findMany({
+      where: { publisherId: id },
+      select: {
+        id: true,
+        title: true,
+        artist: true,
+        type: true,
+        Track: {
+          select: {
+            id: true,
+            SystemPlaylistTrack: { select: { playlistId: true }, take: 1 },
+          },
+        },
+      },
+    });
+
+    const toDelete: Array<{ id: string; title: string; artist: string | null; trackCount: number }> = [];
+    const toKeep: Array<{ id: string; title: string; artist: string | null; trackCount: number; playedTracks: number }> = [];
+
+    for (const child of childFeeds) {
+      // Don't auto-delete podcasts even if mis-attributed; admin can handle those manually.
+      if (child.type === 'podcast') continue;
+
+      const playedTracks = child.Track.filter(t => t.SystemPlaylistTrack.length > 0).length;
+      if (playedTracks === 0) {
+        toDelete.push({
+          id: child.id,
+          title: child.title,
+          artist: child.artist,
+          trackCount: child.Track.length,
+        });
+      } else {
+        toKeep.push({
+          id: child.id,
+          title: child.title,
+          artist: child.artist,
+          trackCount: child.Track.length,
+          playedTracks,
+        });
+      }
+    }
+
+    if (action === 'preview') {
+      return NextResponse.json({
+        publisher: { id: publisher.id, title: publisher.title, musicShowOnly: publisher.musicShowOnly },
+        toDelete,
+        toKeep,
+      });
+    }
+
+    // action === 'cleanup'
+    if (toDelete.length === 0) {
+      return NextResponse.json({
+        publisher: { id: publisher.id, title: publisher.title, musicShowOnly: publisher.musicShowOnly },
+        deletedAlbums: 0,
+        deletedTracks: 0,
+        kept: toKeep.length,
+      });
+    }
+
+    const idsToDelete = toDelete.map(a => a.id);
+    const totalTracks = toDelete.reduce((sum, a) => sum + a.trackCount, 0);
+
+    // Cascade delete via Feed (Track has onDelete: Cascade in schema).
+    await prisma.feed.deleteMany({ where: { id: { in: idsToDelete } } });
+
+    invalidateFeedListCaches();
+
+    return NextResponse.json({
+      publisher: { id: publisher.id, title: publisher.title, musicShowOnly: publisher.musicShowOnly },
+      deletedAlbums: toDelete.length,
+      deletedTracks: totalTracks,
+      kept: toKeep.length,
+    });
+  } catch (error) {
+    console.error('Error running music-show-only cleanup:', error);
+    return NextResponse.json({ error: 'Failed to run cleanup' }, { status: 500 });
+  }
+}

--- a/app/api/admin/publishers/import-albums/route.ts
+++ b/app/api/admin/publishers/import-albums/route.ts
@@ -61,11 +61,14 @@ export async function POST(request: NextRequest) {
     const body = await request.json().catch(() => ({}));
     const { publisherId } = body;
 
-    // Get publishers to process
+    // Get publishers to process. Music-show-only publishers are excluded —
+    // their albums must be imported via the playlist resolver (only when a
+    // curated music show references them), not via this PI-API sweep.
     const publishers = await prisma.feed.findMany({
       where: {
         type: 'publisher',
         status: 'active',
+        musicShowOnly: false,
         ...(publisherId ? { id: publisherId } : {})
       },
       select: {

--- a/app/api/feeds/[id]/process-remote-items/route.ts
+++ b/app/api/feeds/[id]/process-remote-items/route.ts
@@ -50,6 +50,20 @@ export async function POST(
       );
     }
 
+    // Music-show-only publishers don't auto-import their albums.
+    // Only albums referenced by a curated music show (via the playlist resolver) get tracks.
+    if (publisherFeed.musicShowOnly) {
+      console.log(`🎙️  Skipping album auto-import — publisher "${publisherFeed.title}" is music-show-only`);
+      return NextResponse.json({
+        message: 'Publisher is music-show-only; no albums auto-imported',
+        musicShowOnly: true,
+        remoteItems: [],
+        added: 0,
+        skipped: 0,
+        errors: []
+      });
+    }
+
     console.log(`📡 Fetching publisher feed: ${publisherFeed.originalUrl}`);
 
     // Fetch the publisher feed XML

--- a/app/api/feeds/refresh-by-url/route.ts
+++ b/app/api/feeds/refresh-by-url/route.ts
@@ -692,7 +692,7 @@ export async function POST(request: NextRequest) {
 
       // If this is a publisher feed (has no tracks but might have remoteItems), process them
       let remoteItemsResult: RemoteItemResult | null = null;
-      if (updatedFeed && updatedFeed._count.Track === 0) {
+      if (updatedFeed && updatedFeed._count.Track === 0 && !feed.musicShowOnly) {
         console.log(`📡 Feed has 0 tracks, checking for remoteItems...`);
         remoteItemsResult = await processRemoteItems(resolvedUrl, feed.id);
 

--- a/components/AdminPanel.tsx
+++ b/components/AdminPanel.tsx
@@ -125,6 +125,31 @@ export default function AdminPanel() {
     }>;
   } | null>(null);
 
+  // Music-show-only publishers
+  type MusicShowOnlyPublisher = {
+    id: string;
+    title: string;
+    artist: string | null;
+    originalUrl: string;
+    image: string | null;
+    musicShowOnly: boolean;
+    childAlbums: number;
+    childTracks: number;
+  };
+  type CleanupCandidate = {
+    id: string;
+    title: string;
+    artist: string | null;
+    trackCount: number;
+  };
+  type CleanupKept = CleanupCandidate & { playedTracks: number };
+  const [msoPublishers, setMsoPublishers] = useState<MusicShowOnlyPublisher[] | null>(null);
+  const [msoLoading, setMsoLoading] = useState(false);
+  const [msoToggling, setMsoToggling] = useState<Set<string>>(new Set());
+  const [msoPreviewing, setMsoPreviewing] = useState<Set<string>>(new Set());
+  const [msoCleaning, setMsoCleaning] = useState<Set<string>>(new Set());
+  const [msoPreviewByPublisher, setMsoPreviewByPublisher] = useState<Record<string, { toDelete: CleanupCandidate[]; toKeep: CleanupKept[] }>>({});
+
   // Nostr authentication
   const { user: nostrUser, isAuthenticated: isNostrAuthenticated, isLoading: nostrLoading } = useNostr();
 
@@ -246,6 +271,121 @@ export default function AdminPanel() {
       toast.error('Network error loading recent feeds');
     } finally {
       setLoadingRecent(false);
+    }
+  };
+
+  const fetchMsoPublishers = async () => {
+    setMsoLoading(true);
+    try {
+      const response = await fetch('/api/admin/music-show-only-publishers');
+      const data = await response.json();
+      if (response.ok && Array.isArray(data.publishers)) {
+        setMsoPublishers(data.publishers);
+      } else {
+        toast.error(data.error || 'Failed to load publishers');
+      }
+    } catch (error) {
+      console.error('Error fetching publishers:', error);
+      toast.error('Network error loading publishers');
+    } finally {
+      setMsoLoading(false);
+    }
+  };
+
+  const toggleMusicShowOnly = async (id: string, next: boolean) => {
+    setMsoToggling(prev => new Set(prev).add(id));
+    try {
+      const response = await fetch('/api/admin/music-show-only-publishers', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id, musicShowOnly: next }),
+      });
+      const data = await response.json();
+      if (!response.ok) {
+        toast.error(data.error || 'Failed to update flag');
+        return;
+      }
+      setMsoPublishers(prev => prev?.map(p => p.id === id ? { ...p, musicShowOnly: next } : p) ?? null);
+      toast.success(next ? 'Marked music-show-only' : 'Removed music-show-only flag');
+    } catch (error) {
+      console.error('Error toggling flag:', error);
+      toast.error('Network error updating flag');
+    } finally {
+      setMsoToggling(prev => {
+        const n = new Set(prev);
+        n.delete(id);
+        return n;
+      });
+    }
+  };
+
+  const previewMsoCleanup = async (id: string) => {
+    setMsoPreviewing(prev => new Set(prev).add(id));
+    try {
+      const response = await fetch('/api/admin/music-show-only-publishers', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id, action: 'preview' }),
+      });
+      const data = await response.json();
+      if (!response.ok) {
+        toast.error(data.error || 'Failed to preview cleanup');
+        return;
+      }
+      setMsoPreviewByPublisher(prev => ({ ...prev, [id]: { toDelete: data.toDelete, toKeep: data.toKeep } }));
+    } catch (error) {
+      console.error('Error previewing cleanup:', error);
+      toast.error('Network error previewing cleanup');
+    } finally {
+      setMsoPreviewing(prev => {
+        const n = new Set(prev);
+        n.delete(id);
+        return n;
+      });
+    }
+  };
+
+  const runMsoCleanup = async (id: string) => {
+    const preview = msoPreviewByPublisher[id];
+    if (!preview) {
+      toast.error('Run preview first');
+      return;
+    }
+    if (preview.toDelete.length === 0) {
+      toast.info('Nothing to clean up');
+      return;
+    }
+    if (!confirm(`Delete ${preview.toDelete.length} album feed${preview.toDelete.length !== 1 ? 's' : ''} (and their tracks) that aren't on any curated music show?`)) {
+      return;
+    }
+    setMsoCleaning(prev => new Set(prev).add(id));
+    try {
+      const response = await fetch('/api/admin/music-show-only-publishers', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id, action: 'cleanup' }),
+      });
+      const data = await response.json();
+      if (!response.ok) {
+        toast.error(data.error || 'Failed to run cleanup');
+        return;
+      }
+      toast.success(`Deleted ${data.deletedAlbums} album${data.deletedAlbums !== 1 ? 's' : ''} (${data.deletedTracks} tracks)`);
+      setMsoPreviewByPublisher(prev => {
+        const n = { ...prev };
+        delete n[id];
+        return n;
+      });
+      await fetchMsoPublishers();
+    } catch (error) {
+      console.error('Error running cleanup:', error);
+      toast.error('Network error running cleanup');
+    } finally {
+      setMsoCleaning(prev => {
+        const n = new Set(prev);
+        n.delete(id);
+        return n;
+      });
     }
   };
 
@@ -1207,6 +1347,130 @@ export default function AdminPanel() {
             )}
           </div>
         )}
+
+        {/* Music-Show-Only Publishers */}
+        <div className="bg-white/5 backdrop-blur-sm rounded-xl border border-purple-500/30 p-6 mb-8">
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-2xl font-semibold text-purple-300">Music-Show-Only Publishers</h2>
+            <button
+              onClick={fetchMsoPublishers}
+              disabled={msoLoading}
+              className="px-4 py-2 bg-purple-600 hover:bg-purple-700 disabled:bg-gray-600 text-white rounded-lg text-sm transition-colors"
+            >
+              {msoLoading ? 'Loading…' : msoPublishers ? 'Refresh' : 'Load Publishers'}
+            </button>
+          </div>
+          <p className="text-sm text-gray-400 mb-4">
+            Flag a publisher as <strong>music-show-only</strong> to skip auto-importing all of its albums.
+            Only albums whose tracks are referenced by a curated music show (HGH, B4TS, MMM, etc.) will be kept.
+            Use Preview to see what cleanup would delete, then Run to remove non-played albums.
+          </p>
+
+          {msoPublishers && msoPublishers.length === 0 && (
+            <p className="text-gray-400">No publisher feeds found.</p>
+          )}
+
+          {msoPublishers && msoPublishers.length > 0 && (
+            <div className="space-y-3">
+              {msoPublishers.map(pub => {
+                const preview = msoPreviewByPublisher[pub.id];
+                const isToggling = msoToggling.has(pub.id);
+                const isPreviewing = msoPreviewing.has(pub.id);
+                const isCleaning = msoCleaning.has(pub.id);
+                return (
+                  <div key={pub.id} className={`rounded-lg border p-4 ${pub.musicShowOnly ? 'bg-purple-500/10 border-purple-500/40' : 'bg-white/5 border-white/10'}`}>
+                    <div className="flex items-start gap-4">
+                      {pub.image && (
+                        <img src={pub.image} alt="" className="w-12 h-12 rounded object-cover flex-shrink-0" />
+                      )}
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2 flex-wrap">
+                          <span className="font-medium text-white truncate">{pub.title}</span>
+                          {pub.artist && <span className="text-sm text-gray-400 truncate">— {pub.artist}</span>}
+                          {pub.musicShowOnly && (
+                            <span className="text-xs bg-purple-500/30 text-purple-200 px-2 py-0.5 rounded">music-show-only</span>
+                          )}
+                        </div>
+                        <div className="text-xs text-gray-500 mt-1 truncate">{pub.originalUrl}</div>
+                        <div className="text-xs text-gray-400 mt-1">
+                          {pub.childAlbums} album{pub.childAlbums !== 1 ? 's' : ''} · {pub.childTracks} track{pub.childTracks !== 1 ? 's' : ''}
+                        </div>
+                      </div>
+                      <div className="flex items-center gap-2 flex-shrink-0">
+                        <label className="flex items-center gap-2 text-sm text-gray-300 cursor-pointer">
+                          <input
+                            type="checkbox"
+                            checked={pub.musicShowOnly}
+                            disabled={isToggling}
+                            onChange={(e) => toggleMusicShowOnly(pub.id, e.target.checked)}
+                            className="w-4 h-4"
+                          />
+                          <span>{isToggling ? 'Saving…' : 'Music-show-only'}</span>
+                        </label>
+                      </div>
+                    </div>
+
+                    <div className="flex gap-2 mt-3">
+                      <button
+                        onClick={() => previewMsoCleanup(pub.id)}
+                        disabled={isPreviewing || isCleaning}
+                        className="px-3 py-1.5 bg-blue-600/80 hover:bg-blue-600 disabled:bg-gray-600 text-white rounded text-sm transition-colors"
+                      >
+                        {isPreviewing ? 'Previewing…' : 'Preview cleanup'}
+                      </button>
+                      {preview && (
+                        <button
+                          onClick={() => runMsoCleanup(pub.id)}
+                          disabled={isCleaning || preview.toDelete.length === 0}
+                          className="px-3 py-1.5 bg-red-600/80 hover:bg-red-600 disabled:bg-gray-600 text-white rounded text-sm transition-colors"
+                        >
+                          {isCleaning ? 'Deleting…' : `Delete ${preview.toDelete.length} album${preview.toDelete.length !== 1 ? 's' : ''}`}
+                        </button>
+                      )}
+                    </div>
+
+                    {preview && (
+                      <div className="mt-3 text-sm">
+                        <div className="text-gray-300 mb-2">
+                          <span className="text-red-400">{preview.toDelete.length}</span> would be deleted ·{' '}
+                          <span className="text-green-400">{preview.toKeep.length}</span> kept (have played tracks)
+                        </div>
+                        {preview.toDelete.length > 0 && (
+                          <details className="bg-black/30 rounded p-2">
+                            <summary className="cursor-pointer text-red-300 text-xs">Show {preview.toDelete.length} album{preview.toDelete.length !== 1 ? 's' : ''} to delete</summary>
+                            <ul className="mt-2 space-y-1 text-xs text-gray-400 max-h-48 overflow-y-auto">
+                              {preview.toDelete.map(a => (
+                                <li key={a.id}>
+                                  <span className="text-gray-300">{a.title}</span>
+                                  {a.artist && <span> — {a.artist}</span>}
+                                  <span className="text-gray-500"> ({a.trackCount} track{a.trackCount !== 1 ? 's' : ''})</span>
+                                </li>
+                              ))}
+                            </ul>
+                          </details>
+                        )}
+                        {preview.toKeep.length > 0 && (
+                          <details className="bg-black/30 rounded p-2 mt-2">
+                            <summary className="cursor-pointer text-green-300 text-xs">Show {preview.toKeep.length} album{preview.toKeep.length !== 1 ? 's' : ''} kept</summary>
+                            <ul className="mt-2 space-y-1 text-xs text-gray-400 max-h-48 overflow-y-auto">
+                              {preview.toKeep.map(a => (
+                                <li key={a.id}>
+                                  <span className="text-gray-300">{a.title}</span>
+                                  {a.artist && <span> — {a.artist}</span>}
+                                  <span className="text-gray-500"> ({a.playedTracks}/{a.trackCount} played)</span>
+                                </li>
+                              ))}
+                            </ul>
+                          </details>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
 
         {/* Delete by URL */}
         <div className="bg-white/5 backdrop-blur-sm rounded-xl border border-red-500/30 p-6 mb-8">

--- a/prisma/migrations/20260426000000_add_music_show_only_to_feed/migration.sql
+++ b/prisma/migrations/20260426000000_add_music_show_only_to_feed/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Feed" ADD COLUMN "musicShowOnly" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -110,6 +110,7 @@ model Feed {
   podcastCategories   String[]  @default([])
   oldestItemPubdate   DateTime?
   persons             Json?
+  musicShowOnly       Boolean   @default(false)
   Feed              Feed?     @relation("FeedToFeed", fields: [publisherId], references: [id])
   other_Feed        Feed[]    @relation("FeedToFeed")
   Track             Track[]


### PR DESCRIPTION
Adds a per-publisher "music-show-only" toggle so spammy artists' bulk
catalogs aren't auto-imported. Flagged publishers skip the auto-album
sweep (process-remote-items, refresh-by-url's inline pass, and the
nightly Step 5b PI-API import). Albums still appear if a curated music
show references one of their tracks — the playlist resolver imports
them as usual.

New admin section lists publishers with toggle, preview cleanup (shows
which child albums have zero tracks in any SystemPlaylistTrack), and
run cleanup (cascade-deletes those albums + their tracks). Albums with
≥1 played track are kept in full.