### PR TITLE
feat(admin): bulk "Delete unplayed" button on music-show-only search results

### DIFF
--- a/app/api/admin/music-show-only-publishers/cleanup-by-ids/route.ts
+++ b/app/api/admin/music-show-only-publishers/cleanup-by-ids/route.ts
@@ -1,0 +1,96 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { invalidateAlbumsFastCache } from '@/lib/caches/albums-fast-cache';
+import { invalidateSearchCache } from '@/lib/caches/search-cache';
+
+// POST /api/admin/music-show-only-publishers/cleanup-by-ids
+// Body: { ids: string[], dryRun?: boolean }
+//
+// Bulk cleanup for the artist-name search panel: caller passes the set of
+// already-imported feed IDs visible in the search results, server filters to
+// the ones that are NOT podcasts and have NO SystemPlaylistTrack-linked
+// tracks, and deletes them (or returns the to-delete/to-keep split when
+// dryRun=true). Mirrors the per-publisher cleanup logic in `../route.ts` but
+// operates on a flat list of feed IDs instead of children of a publisher.
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { ids, dryRun } = body as { ids?: string[]; dryRun?: boolean };
+
+    if (!Array.isArray(ids) || ids.length === 0) {
+      return NextResponse.json(
+        { error: 'Body must include { ids: string[] } with at least one id' },
+        { status: 400 }
+      );
+    }
+
+    const feeds = await prisma.feed.findMany({
+      where: { id: { in: ids } },
+      select: {
+        id: true,
+        title: true,
+        artist: true,
+        type: true,
+        Track: {
+          select: {
+            id: true,
+            SystemPlaylistTrack: { select: { playlistId: true }, take: 1 },
+          },
+        },
+      },
+    });
+
+    type Candidate = { id: string; title: string; artist: string | null; trackCount: number };
+    type Kept = Candidate & { playedTracks: number };
+    const toDelete: Candidate[] = [];
+    const toKeep: Kept[] = [];
+
+    for (const feed of feeds) {
+      // Don't auto-delete podcasts even if they slipped into search results.
+      if (feed.type === 'podcast') continue;
+
+      const playedTracks = feed.Track.filter(t => t.SystemPlaylistTrack.length > 0).length;
+      if (playedTracks === 0) {
+        toDelete.push({
+          id: feed.id,
+          title: feed.title,
+          artist: feed.artist,
+          trackCount: feed.Track.length,
+        });
+      } else {
+        toKeep.push({
+          id: feed.id,
+          title: feed.title,
+          artist: feed.artist,
+          trackCount: feed.Track.length,
+          playedTracks,
+        });
+      }
+    }
+
+    if (dryRun) {
+      return NextResponse.json({ toDelete, toKeep });
+    }
+
+    if (toDelete.length === 0) {
+      return NextResponse.json({ deletedAlbums: 0, deletedTracks: 0, kept: toKeep.length });
+    }
+
+    const idsToDelete = toDelete.map(a => a.id);
+    const totalTracks = toDelete.reduce((sum, a) => sum + a.trackCount, 0);
+
+    await prisma.feed.deleteMany({ where: { id: { in: idsToDelete } } });
+
+    invalidateAlbumsFastCache();
+    invalidateSearchCache();
+
+    return NextResponse.json({
+      deletedAlbums: toDelete.length,
+      deletedTracks: totalTracks,
+      kept: toKeep.length,
+    });
+  } catch (error) {
+    console.error('Error running cleanup-by-ids:', error);
+    return NextResponse.json({ error: 'Failed to run cleanup' }, { status: 500 });
+  }
+}

--- a/components/AdminPanel.tsx
+++ b/components/AdminPanel.tsx
@@ -163,6 +163,7 @@ export default function AdminPanel() {
   const [msoSearching, setMsoSearching] = useState(false);
   const [msoSearchResults, setMsoSearchResults] = useState<MsoSearchResult[] | null>(null);
   const [msoImporting, setMsoImporting] = useState<Set<string>>(new Set());
+  const [msoSearchCleaning, setMsoSearchCleaning] = useState(false);
 
   // Nostr authentication
   const { user: nostrUser, isAuthenticated: isNostrAuthenticated, isLoading: nostrLoading } = useNostr();
@@ -454,6 +455,77 @@ export default function AdminPanel() {
         n.delete(result.feedUrl);
         return n;
       });
+    }
+  };
+
+  const deleteUnplayedFromSearch = async () => {
+    if (!msoSearchResults) return;
+    const existingIds = msoSearchResults
+      .map(r => r.existing?.id)
+      .filter((id): id is string => Boolean(id));
+    if (existingIds.length === 0) {
+      toast.info('No imported feeds in these search results');
+      return;
+    }
+
+    setMsoSearchCleaning(true);
+    try {
+      const previewRes = await fetch('/api/admin/music-show-only-publishers/cleanup-by-ids', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ids: existingIds, dryRun: true }),
+      });
+      const previewData = await previewRes.json();
+      if (!previewRes.ok) {
+        toast.error(previewData.error || 'Failed to preview cleanup');
+        return;
+      }
+
+      const toDelete: CleanupCandidate[] = previewData.toDelete ?? [];
+      const toKeep: CleanupKept[] = previewData.toKeep ?? [];
+      if (toDelete.length === 0) {
+        toast.info(`Nothing to delete — all ${toKeep.length} imported feed${toKeep.length !== 1 ? 's' : ''} have played tracks`);
+        return;
+      }
+
+      const trackTotal = toDelete.reduce((sum, a) => sum + a.trackCount, 0);
+      const keepNote = toKeep.length > 0
+        ? ` ${toKeep.length} played feed${toKeep.length !== 1 ? 's' : ''} will be kept.`
+        : '';
+      const ok = confirm(
+        `Delete ${toDelete.length} unplayed feed${toDelete.length !== 1 ? 's' : ''} ` +
+        `(${trackTotal} track${trackTotal !== 1 ? 's' : ''}) from these search results?${keepNote}`
+      );
+      if (!ok) return;
+
+      const cleanupRes = await fetch('/api/admin/music-show-only-publishers/cleanup-by-ids', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ids: existingIds }),
+      });
+      const cleanupData = await cleanupRes.json();
+      if (!cleanupRes.ok) {
+        toast.error(cleanupData.error || 'Failed to run cleanup');
+        return;
+      }
+      toast.success(`Deleted ${cleanupData.deletedAlbums} feed${cleanupData.deletedAlbums !== 1 ? 's' : ''} (${cleanupData.deletedTracks} tracks)`);
+
+      // Drop deleted entries from the search results so the row state matches DB.
+      const deletedIds = new Set(toDelete.map(a => a.id));
+      setMsoSearchResults(prev =>
+        prev?.map(r =>
+          r.existing && deletedIds.has(r.existing.id) ? { ...r, existing: null } : r
+        ) ?? null
+      );
+
+      if (msoPublishers) {
+        await fetchMsoPublishers();
+      }
+    } catch (error) {
+      console.error('Error deleting unplayed from search:', error);
+      toast.error('Network error during cleanup');
+    } finally {
+      setMsoSearchCleaning(false);
     }
   };
 
@@ -1469,8 +1541,24 @@ export default function AdminPanel() {
               If nothing matches, paste the URL into the &ldquo;Add or Update Feed&rdquo; section above.
             </p>
 
-            {msoSearchResults && msoSearchResults.length > 0 && (
+            {msoSearchResults && msoSearchResults.length > 0 && (() => {
+              const importedCount = msoSearchResults.filter(r => r.existing).length;
+              return (
               <div className="mt-4 space-y-2">
+                {importedCount > 0 && (
+                  <div className="flex items-center justify-between bg-red-500/10 border border-red-500/30 rounded p-3">
+                    <span className="text-sm text-gray-300">
+                      <span className="text-red-300 font-medium">{importedCount}</span> already in DB — bulk-delete those with no plays on any music show
+                    </span>
+                    <button
+                      onClick={deleteUnplayedFromSearch}
+                      disabled={msoSearchCleaning}
+                      className="px-3 py-1.5 bg-red-600/80 hover:bg-red-600 disabled:bg-gray-600 text-white rounded text-sm transition-colors flex-shrink-0 ml-3"
+                    >
+                      {msoSearchCleaning ? 'Deleting…' : 'Delete unplayed'}
+                    </button>
+                  </div>
+                )}
                 {msoSearchResults.map(r => {
                   const isImporting = msoImporting.has(r.feedUrl);
                   const existing = r.existing;
@@ -1517,7 +1605,8 @@ export default function AdminPanel() {
                   );
                 })}
               </div>
-            )}
+              );
+            })()}
             {msoSearchResults && msoSearchResults.length === 0 && (
               <p className="text-sm text-gray-500 mt-3">No publisher feeds found for &ldquo;{msoSearchQuery}&rdquo;.</p>
             )}


### PR DESCRIPTION
## Summary
- Adds a single **"Delete unplayed"** button at the top of the artist-name search panel in the Music-Show-Only Publishers admin section.
- Operates on every already-imported feed in the visible search results: deletes those with no `SystemPlaylistTrack`-linked tracks, keeps the played ones, ignores not-yet-imported PI candidates.
- Backed by new `POST /api/admin/music-show-only-publishers/cleanup-by-ids` (takes `{ ids: string[], dryRun?: boolean }`).

This is a spam-cleanup tool, not an inspection one — the confirm dialog only shows counts, not the list of feeds to delete.

## Test plan
- [ ] Open `/admin` → Music-Show-Only Publishers → search for an artist with multiple already-imported feeds
- [ ] Red banner appears above the result rows: *"N already in DB — bulk-delete those with no plays on any music show"* with a **Delete unplayed** button
- [ ] Click → confirm dialog shows *"Delete X unplayed feeds (Y tracks) from these search results? Z played feeds will be kept."*
- [ ] Cancel → no DB change
- [ ] Confirm → success toast; deleted rows in the visible search results lose their `existing` annotation (button flips back to "Add as music-show-only")
- [ ] If a played-only artist is searched, button shows toast: *"Nothing to delete — all N imported feeds have played tracks"*
- [ ] If no imported feeds in results, banner is hidden entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)