### PR TITLE
feat(admin): auto-offer cleanup after flagging an existing publisher

### DIFF
--- a/components/AdminPanel.tsx
+++ b/components/AdminPanel.tsx
@@ -446,6 +446,11 @@ export default function AdminPanel() {
       if (msoPublishers) {
         await fetchMsoPublishers();
       }
+      // For promotions (publisher already existed), offer to clean up its
+      // unplayed children. Skipped for brand-new entries — no children to clean.
+      if (data.alreadyExisted) {
+        await deleteUnplayedAlbums(data.feed.id, data.feed.title);
+      }
     } catch (error) {
       console.error('Error importing publisher:', error);
       toast.error('Network error during import');
@@ -1501,9 +1506,10 @@ export default function AdminPanel() {
             </button>
           </div>
           <p className="text-sm text-gray-400 mb-4">
-            Flag a publisher as <strong>music-show-only</strong> to skip auto-importing all of its albums.
+            Flag a publisher as <strong>music-show-only</strong> to skip auto-importing its albums going forward.
             Only albums whose tracks are referenced by a curated music show (HGH, B4TS, MMM, etc.) will be kept.
-            Use Preview to see what cleanup would delete, then Run to remove non-played albums.
+            Flagging an existing publisher also offers to delete its current unplayed albums in the same step;
+            <strong> Delete unplayed albums</strong> on the loaded list does the same on demand.
           </p>
 
           {/* Artist-name search */}


### PR DESCRIPTION
## Summary
- When **Flag existing** succeeds in the Music-Show-Only search panel and the publisher row already existed in the DB (a promotion, not a new entry), immediately fires the same preview→confirm→cleanup flow used by the loaded-publishers list.
- Brand-new entries are skipped — they have no children to clean.
- Closes the workflow gap where flagging a publisher didn't touch its already-imported spam albums (they needed a separate cleanup pass that wasn't obvious).

Also refreshes the help text — drops the stale "Use Preview…" line and explains the new combined behavior.

## Test plan
- [ ] Search a publisher already in the DB with unplayed children → click **Flag existing** → confirm dialog appears: *"Delete N unplayed albums (X tracks) from <publisher>?"* → confirm → both flag + delete happen
- [ ] Cancel the confirm → publisher is still flagged but no deletion happens
- [ ] Click **Add as music-show-only** on a brand-new entry → publisher is added/flagged, no cleanup confirm appears (no children to clean)
- [ ] Click **Flag existing** on a publisher whose children are all already played → toast: *"Nothing to delete — all N albums have played tracks"*

🤖 Generated with [Claude Code](https://claude.com/claude-code)