### PR TITLE
fix(admin): include orphan albums by artist in music-show-only cleanup

### DIFF
--- a/app/api/admin/music-show-only-publishers/route.ts
+++ b/app/api/admin/music-show-only-publishers/route.ts
@@ -174,7 +174,7 @@ export async function POST(request: NextRequest) {
 
     const publisher = await prisma.feed.findUnique({
       where: { id },
-      select: { id: true, type: true, title: true, musicShowOnly: true },
+      select: { id: true, type: true, title: true, artist: true, musicShowOnly: true },
     });
     if (!publisher) {
       return NextResponse.json({ error: 'Publisher not found' }, { status: 404 });
@@ -186,9 +186,30 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Find all child album feeds (publisherId points at this publisher).
+    // Find child album feeds. Two cohorts share the same delete-vs-keep rules:
+    //  1. publisherId points at this publisher (the obvious case).
+    //  2. publisherId is null but artist matches — these orphans slip past
+    //     per-publisher cleanup whenever the original import didn't link them
+    //     (different publisher row, or imported before any publisher existed).
+    //     Without this, flagging MSO + clicking "Delete unplayed albums"
+    //     leaves the artist's albums stuck in the grid and the user re-flags
+    //     thinking the action didn't take. Mirrors the artist-name fallback
+    //     used by the publisher-album cron in
+    //     `app/api/admin/publishers/import-albums/route.ts`.
+    const artistKey = (publisher.artist || publisher.title || '').trim();
     const childFeeds = await prisma.feed.findMany({
-      where: { publisherId: id },
+      where: {
+        OR: [
+          { publisherId: id },
+          ...(artistKey
+            ? [{
+                publisherId: null,
+                type: { in: ['album', 'music'] },
+                artist: { equals: artistKey, mode: 'insensitive' as const },
+              }]
+            : []),
+        ],
+      },
       select: {
         id: true,
         title: true,


### PR DESCRIPTION
Per-publisher cleanup only deleted feeds linked via publisherId.
Albums for the same artist with publisherId=null (imported via a
different path or before any publisher row existed) were silently
skipped, so flagging an artist MSO + clicking "Delete unplayed
albums" appeared to do nothing and the user re-flagged thinking the
action hadn't taken.

Mirror the artist-name fallback already used by the publisher-album
cron in app/api/admin/publishers/import-albums/route.ts: when running
preview/cleanup, also pick up publisherId=null album/music feeds
whose artist matches the publisher's artist (or title fallback,
case-insensitive). Same delete-vs-keep rule — feeds with any
SystemPlaylistTrack-linked track stay.

https://claude.ai/code/session_01UB6df9ar9VF6MBaFyvhUBk