### PR TITLE
fix: show boost buttons on New tab by falling back to track-level V4V

### DIFF
--- a/app/api/feeds/recent/route.ts
+++ b/app/api/feeds/recent/route.ts
@@ -200,8 +200,8 @@ export async function GET(request: Request) {
           valueTimeSplits: track.valueTimeSplits || undefined,
           persons: (track as { persons?: unknown }).persons || undefined,
         })),
-        v4vRecipient: feed.v4vRecipient,
-        v4vValue: feed.v4vValue,
+        v4vRecipient: feed.v4vRecipient || feed.Track?.[0]?.v4vRecipient || null,
+        v4vValue: feed.v4vValue || feed.Track?.[0]?.v4vValue || null,
         persons: (feed as { persons?: unknown }).persons || undefined,
         trackCount: feed._count?.Track || 0,
       }));


### PR DESCRIPTION
albums-fast already falls back to feed.Track?.[0]?.v4vRecipient when
feed-level V4V is null. feeds/recent was missing the same fallback, so
albums whose V4V data lives at the track level (not the feed level) had
no boost button on the New tab even though they showed one on other tabs.

https://claude.ai/code/session_01TLagc8JSKYEoQvUfRze7Lg