### PR TITLE
Surface albums with new tracks in the "new" filter

### DIFF
--- a/app/api/admin/feeds/[id]/reparse/route.ts
+++ b/app/api/admin/feeds/[id]/reparse/route.ts
@@ -230,6 +230,12 @@ export async function POST(
           skipDuplicates: true
         });
 
+        // Mark the feed as updated with new tracks so it surfaces in "new"
+        await prisma.feed.update({
+          where: { id: feed.id },
+          data: { lastNewTrackAt: new Date() }
+        });
+
         console.log(`✅ Added ${newItems.length} new tracks`);
       }
 

--- a/app/api/feeds/recent/route.ts
+++ b/app/api/feeds/recent/route.ts
@@ -48,6 +48,7 @@ export async function GET(request: Request) {
       select: {
         id: true,
         createdAt: true,
+        lastNewTrackAt: true,
         originalUrl: true,
         title: true,
         artist: true,
@@ -98,6 +99,16 @@ export async function GET(request: Request) {
         }) &&
         !msoArtistKeys.has((f.artist || '').trim().toLowerCase())
     );
+
+    // Sort by most recent activity: new-track additions float existing albums to the top
+    // alongside newly minted feeds. lastNewTrackAt is only set when a genuinely new
+    // track row is created (not metadata refreshes), so this doesn't cause the false-
+    // positive problem that MAX(Track.createdAt) did.
+    eligible.sort((a, b) => {
+      const aTime = Math.max(a.createdAt.getTime(), (a.lastNewTrackAt ?? a.createdAt).getTime());
+      const bTime = Math.max(b.createdAt.getTime(), (b.lastNewTrackAt ?? b.createdAt).getTime());
+      return bTime - aTime;
+    });
 
     const total = eligible.length;
     const pageIds = eligible.slice(offset, offset + limit).map((f) => f.id);

--- a/app/api/feeds/refresh-by-url/route.ts
+++ b/app/api/feeds/refresh-by-url/route.ts
@@ -678,8 +678,14 @@ export async function POST(request: NextRequest) {
           data: tracksData,
           skipDuplicates: true
         });
+
+        // Mark the feed as updated with new tracks so it surfaces in "new"
+        await prisma.feed.update({
+          where: { id: feed.id },
+          data: { lastNewTrackAt: new Date() }
+        });
       }
-      
+
       // Get updated feed with counts
       let updatedFeed = await prisma.feed.findUnique({
         where: { id: feed.id },

--- a/lib/feed-parsing.ts
+++ b/lib/feed-parsing.ts
@@ -304,6 +304,7 @@ export async function importFeedToDatabase(feedData: any, episodes: ParsedEpisod
 
     // Import tracks/episodes
     let trackCount = 0;
+    let newTracksCreated = 0;
 
     // Batch lookup: Get all existing tracks by guid in one query (fixes N+1)
     const episodeGuids = episodes.map(e => e.guid).filter(Boolean);
@@ -403,6 +404,7 @@ export async function importFeedToDatabase(feedData: any, episodes: ParsedEpisod
             }
           });
           trackCount++;
+          newTracksCreated++;
         } else {
           // Update existing track with trackOrder and v4v data
           await prisma.track.update({
@@ -422,6 +424,15 @@ export async function importFeedToDatabase(feedData: any, episodes: ParsedEpisod
       } catch (error) {
         console.warn(`⚠️ Failed to import track "${episode.title}":`, error instanceof Error ? error.message : error);
       }
+    }
+
+    // Update lastNewTrackAt when new tracks are added to an existing feed
+    // (not on initial import — createdAt already captures that for "new" sorting)
+    if (newTracksCreated > 0 && existingTrackCount > 0) {
+      await prisma.feed.update({
+        where: { id: feed.id },
+        data: { lastNewTrackAt: new Date() }
+      });
     }
 
     // Backfill oldestItemPubdate from tracks just imported

--- a/prisma/migrations/20260514000000_add_last_new_track_at/migration.sql
+++ b/prisma/migrations/20260514000000_add_last_new_track_at/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Feed" ADD COLUMN "lastNewTrackAt" TIMESTAMP(3);
+
+-- CreateIndex
+CREATE INDEX "Feed_lastNewTrackAt_idx" ON "Feed"("lastNewTrackAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -111,6 +111,7 @@ model Feed {
   oldestItemPubdate   DateTime?
   persons             Json?
   musicShowOnly       Boolean   @default(false)
+  lastNewTrackAt      DateTime?
   Feed              Feed?     @relation("FeedToFeed", fields: [publisherId], references: [id])
   other_Feed        Feed[]    @relation("FeedToFeed")
   Track             Track[]
@@ -126,6 +127,7 @@ model Feed {
   @@index([status, priority])
   @@index([status, type])
   @@index([type])
+  @@index([lastNewTrackAt])
 }
 
 model Follow {


### PR DESCRIPTION
Adds Feed.lastNewTrackAt, set only when a genuinely new track row is
created (not metadata refreshes). The "new" feed now sorts by
max(createdAt, lastNewTrackAt) so albums that receive a new track float
to the top alongside newly minted feeds, without the false-positive
problem of sorting by Track.createdAt (which changed on every reparse).

Three creation paths updated: importFeedToDatabase, reparse route, and
refresh-by-url route. Migration adds the column and an index.

https://claude.ai/code/session_013nyY34yDZiWfD5RSeEPtCQ