### PR TITLE
fix(ios): sync body background to album color in NowPlaying screen

### DIFF
--- a/components/NowPlayingScreen.tsx
+++ b/components/NowPlayingScreen.tsx
@@ -254,6 +254,18 @@ export default function NowPlayingScreen({ isOpen, onClose }: NowPlayingScreenPr
     };
   }, [shouldShow]);
 
+  // Sync body background to album color while open so iOS elastic overscroll
+  // areas show the album color instead of the white page background.
+  useEffect(() => {
+    if (!shouldShow) return;
+    const body = document.body;
+    const prev = body.style.backgroundColor;
+    body.style.backgroundColor = contrastColors.backgroundColor;
+    return () => {
+      body.style.backgroundColor = prev;
+    };
+  }, [shouldShow, contrastColors.backgroundColor]);
+
   // Debug: Log V4V data availability
   useEffect(() => {
     if (currentTrack) {


### PR DESCRIPTION
On iOS PWA, the elastic overscroll (rubber-band) effect reveals the
body background behind the fixed overlay. Set document.body.style
.backgroundColor to the album art color while the screen is open so
the full page — including overscroll areas — shows the dynamic color.
Restores the original value on close.

https://claude.ai/code/session_01NQRsh3uhNXgbRLWEQo6RFw