### PR TITLE
fix(lightning): extract keysend routing TLVs from Helipad metadata into WebLN payload

### DIFF
--- a/components/Lightning/BitcoinConnectProvider.tsx
+++ b/components/Lightning/BitcoinConnectProvider.tsx
@@ -631,6 +631,19 @@ export function BitcoinConnectProvider({ children }: { children: React.ReactNode
 
       const customRecords: Record<string, string> = {};
 
+      // Extract routing custom records from helipadMetadata before building the Helipad JSON.
+      // These records (e.g. Alby's account-routing TLV) must appear as individual TLV entries
+      // in the WebLN keysend payload so the receiving node knows which account to credit.
+      // Embedding them inside the Helipad JSON blob (TLV 7629169) is not enough — the node
+      // inspects raw TLV records, not the JSON payload.
+      const { customRecords: routingCustomRecords, ...helipadMetadataWithoutRouting } =
+        (helipadMetadata as any) || {};
+      if (routingCustomRecords && typeof routingCustomRecords === 'object') {
+        for (const [key, value] of Object.entries(routingCustomRecords as Record<string, string>)) {
+          if (key && value != null) customRecords[key] = String(value);
+        }
+      }
+
       // Add boostagram message if provided
       if (message) {
         // TLV record 34349334 is used for boostagram messages
@@ -638,12 +651,12 @@ export function BitcoinConnectProvider({ children }: { children: React.ReactNode
         customRecords['34349334'] = message;
       }
 
-      // Add Helipad metadata if provided
+      // Add Helipad metadata if provided (routing customRecords excluded — already added above)
       if (helipadMetadata) {
         try {
           // Clean the metadata object to remove any undefined/null values that could cause issues
           const cleanMetadata = Object.fromEntries(
-            Object.entries(helipadMetadata).filter(([_, value]) => value !== undefined && value !== null)
+            Object.entries(helipadMetadataWithoutRouting).filter(([_, value]) => value !== undefined && value !== null)
           );
 
           // TLV record 7629169 is used for Helipad/Podcast 2.0 metadata (JSON)

--- a/components/Lightning/BoostButton.tsx
+++ b/components/Lightning/BoostButton.tsx
@@ -1000,7 +1000,8 @@ export function BoostButton({
         message,
         helipadMetadata,
         onProgress,
-        walletProviderType
+        walletProviderType,
+        supportsKeysend
       );
 
       if (!result.success) {


### PR DESCRIPTION
Custodial Lightning providers (Alby) require a routing custom record in
the WebLN keysend payload to credit the right account. The routing key/value
from keysendFallback was being merged into helipadMetadata.customRecords and
then JSON-serialised into TLV 7629169, where the receiving node never sees it.

Extract helipadMetadata.customRecords before building the Helipad JSON blob and
add each entry directly to the WebLN customRecords map so the routing TLV is
present as a first-class keysend record. Without this, keysend to addresses like
podcastindex@getalby.com silently fails and the LNURL fallback carries the full
payment burden.

Also pass supportsKeysend to sendMultiRecipientPayment so the service has
accurate wallet capability information rather than inferring it from undefined.

https://claude.ai/code/session_016FL4P76Zrc1uRjFX27s2xD