### PR TITLE
Fix refresh-playlists workflow crash on curl network errors

### DIFF
--- a/.github/workflows/refresh-playlists.yml
+++ b/.github/workflows/refresh-playlists.yml
@@ -42,7 +42,7 @@ jobs:
         echo ""
         echo "📋 Step 2: Reparsing music feeds to detect new tracks..."
 
-        REPARSE_RESPONSE=$(curl -s -X POST -w "\n%{http_code}" "${BASE_URL}/api/admin/reparse-feeds?type=all&maxAgeHours=24&limit=5000")
+        REPARSE_RESPONSE=$(curl -s -X POST -w "\n%{http_code}" "${BASE_URL}/api/admin/reparse-feeds?type=all&maxAgeHours=24&limit=5000") || REPARSE_RESPONSE=$'\n000'
         HTTP_CODE=$(echo "$REPARSE_RESPONSE" | tail -n1)
         RESPONSE_BODY=$(echo "$REPARSE_RESPONSE" | sed '$d')
 
@@ -82,7 +82,7 @@ jobs:
         echo ""
         echo "📋 Step 2c: Fixing stale VTS data..."
 
-        VTS_FIX_RESPONSE=$(curl -s -X POST -w "\n%{http_code}" "${BASE_URL}/api/admin/fix-stale-vts")
+        VTS_FIX_RESPONSE=$(curl -s -X POST -w "\n%{http_code}" "${BASE_URL}/api/admin/fix-stale-vts") || VTS_FIX_RESPONSE=$'\n000'
         HTTP_CODE=$(echo "$VTS_FIX_RESPONSE" | tail -n1)
         RESPONSE_BODY=$(echo "$VTS_FIX_RESPONSE" | sed '$d')
 
@@ -158,7 +158,7 @@ jobs:
         echo ""
         echo "📋 Step 5: Parsing publisher feeds to update album relationships..."
 
-        PUBLISHER_RESPONSE=$(curl -s -X POST -w "\n%{http_code}" "${BASE_URL}/api/parse-feeds?action=parse-publishers")
+        PUBLISHER_RESPONSE=$(curl -s -X POST -w "\n%{http_code}" "${BASE_URL}/api/parse-feeds?action=parse-publishers") || PUBLISHER_RESPONSE=$'\n000'
         HTTP_CODE=$(echo "$PUBLISHER_RESPONSE" | tail -n1)
         RESPONSE_BODY=$(echo "$PUBLISHER_RESPONSE" | sed '$d')
 
@@ -174,7 +174,7 @@ jobs:
         echo ""
         echo "📋 Step 5b: Importing missing albums from publisher feeds..."
 
-        IMPORT_RESPONSE=$(curl -s -X POST -w "\n%{http_code}" "${BASE_URL}/api/admin/publishers/import-albums")
+        IMPORT_RESPONSE=$(curl -s -X POST -w "\n%{http_code}" "${BASE_URL}/api/admin/publishers/import-albums") || IMPORT_RESPONSE=$'\n000'
         HTTP_CODE=$(echo "$IMPORT_RESPONSE" | tail -n1)
         RESPONSE_BODY=$(echo "$IMPORT_RESPONSE" | sed '$d')
 


### PR DESCRIPTION
Long-running curl calls (reparse-feeds, fix-stale-vts, parse-publishers,
import-albums) were killing the entire workflow when Railway's proxy dropped
the connection mid-response (exit code 56). GitHub Actions uses bash -e, so
a failed command substitution VAR=$(curl ...) exits immediately before the
existing HTTP-code error-handling branches can run.

Added || VAR=$'\n000' fallback on each assignment so network failures are
surfaced as warnings and the remaining steps continue.

https://claude.ai/code/session_01U84gZrMeP8xrwpcxhCasbz