### PR TITLE
Fix podcast episodes appearing in Favorite Tracks shuffle

### DIFF
--- a/app/api/favorites/tracks/route.ts
+++ b/app/api/favorites/tracks/route.ts
@@ -58,7 +58,8 @@ export async function GET(request: NextRequest) {
             guid: true,
             v4vValue: true,
             v4vRecipient: true,
-            originalUrl: true
+            originalUrl: true,
+            type: true
           }
         }
       }

--- a/app/favorites/page.tsx
+++ b/app/favorites/page.tsx
@@ -47,6 +47,7 @@ interface FavoriteTrack {
     v4vValue?: any;
     v4vRecipient?: string | null;
     originalUrl?: string | null;
+    type?: string | null;
   };
 }
 
@@ -755,8 +756,10 @@ function FavoritesPageContent() {
       return;
     }
 
-    // Shuffle the tracks array
-    const shuffled = [...favoriteTracks].sort(() => Math.random() - 0.5);
+    // Shuffle the tracks array, excluding podcast episodes
+    const shuffled = [...favoriteTracks]
+      .filter(track => track.Feed?.type !== 'podcast')
+      .sort(() => Math.random() - 0.5);
 
     // Create a playlist album from all shuffled tracks
     const shuffleAlbum: RSSAlbum = {


### PR DESCRIPTION
Exclude tracks from feeds typed as 'podcast' when building the shuffle
queue. Also includes Feed.type in the favorites/tracks API response so
the client has the data to filter on.

https://claude.ai/code/session_012u9izZAyzDXVHXcnfTb6R9