### PR TITLE
fix(favorites): add Feed.type to all track selects to fix Railway build

### DIFF
--- a/app/api/favorites/tracks/route.ts
+++ b/app/api/favorites/tracks/route.ts
@@ -83,7 +83,8 @@ export async function GET(request: NextRequest) {
               guid: true,
               v4vValue: true,
               v4vRecipient: true,
-              originalUrl: true
+              originalUrl: true,
+              type: true
             }
           }
         }
@@ -110,7 +111,8 @@ export async function GET(request: NextRequest) {
                 guid: true,
                 v4vValue: true,
                 v4vRecipient: true,
-                originalUrl: true
+                originalUrl: true,
+                type: true
               }
             }
           }


### PR DESCRIPTION
## Problem
The last commit on `main` (#145) failed to deploy on Railway. The Docker build dies at the type-check step:

```
./app/api/favorites/tracks/route.ts:93:7
Type error: ... Property 'type' is missing in type '{ ... }' but required in type '{ ... type: string ... }'.
```

## Root cause
PR #145 added `type: true` to the `Feed` select of only the **match-by-id** Track query. But `favorites/tracks` runs three queries (id, guid, audioUrl) that get merged into one `tracks` array. TypeScript infers `tracks` from the first (now has `type`), so concatenating the guid/audioUrl results — whose `Feed` lacks `type` — is a type error.

## Fix
Add `type: true` to the `Feed` select in the `tracksByGuid` and `tracksByAudioUrl` queries so all three arrays share the same shape. As a bonus, guid/audioUrl-matched favorites now carry `Feed.type`, so the `/favorites` shuffle podcast filter applies to them too.

## Verification
- `npm run build` passes locally (exit 0, no type error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)