### PR TITLE
fix: blacklist Phantom Power Business Hour (talk podcast with medium=music)

### DIFF
--- a/lib/feed-exclusions.ts
+++ b/lib/feed-exclusions.ts
@@ -8,6 +8,9 @@ export const BLACKLISTED_FEED_IDS = [
   'bitpunkfm-unwound',
   'bitpunk-fm-unwound-1768079479444',  // bitpunk.fm unwound podcast
   'album-1774815395173-2v8ktsh5s',     // No Agenda Show — talk podcast, not music
+  // Phantom Power Business Hour — talk podcast with medium=music; without the
+  // ban the 4 AM cron re-mints it from PI artist search every time it's deleted
+  'phantom-power-music-phantom-power-business-hour',
 ];
 
 // Feed URLs that should never be imported
@@ -27,6 +30,7 @@ export const BLACKLISTED_FEED_URLS = [
   'https://wavlake.com/feed/music/b7f701d7-5499-48be-8394-fcd633c649bb',  // Dancing With A Ghost
   'https://wavlake.com/feed/music/e0c852e7-a118-46b0-a751-4e42ed6e0b6c',  // Shadowbanned
   'https://anchor.fm/s/1125b8ad4/podcast/rss',  // Unknown podcast — auto-imported without authorization
+  'https://epochradio.com/feed/phantom-power-business-hour',  // Phantom Power Business Hour — talk podcast, not music
 ];
 
 // Feed URLs that back a curated playlist. Not blacklisted (admin can add them as


### PR DESCRIPTION
## Problem
https://stablekraft.app/album/phantom-power-business-hour kept reappearing in the "new" tab after being deleted.

## Root cause
The feed (`https://epochradio.com/feed/phantom-power-business-hour`) declares `<podcast:medium>music</podcast:medium>` even though it's a talk show, so:
- the `medium=podcast` → `type:'podcast'` auto-detect never catches it, and
- the nightly 4 AM cron (Step 5b → `POST /api/admin/publishers/import-albums`) finds it via the Podcast Index artist search for "Phantom Power Music" (`medium='music'` + exact author match) and re-creates it as `type='album'` with a fresh `createdAt` — putting it back at the top of the "new" tab every time it's deleted.

## Fix
Add the feed URL + id to the blacklists in `lib/feed-exclusions.ts` (same precedent as No Agenda Show). The URL entry blocks the Step 5b cron and `/api/feeds/exists`; the id entry covers the album grid/search if the same slug ever re-mints. The "Phantom Power Music" publisher and its actual music albums are untouched.

After merge + deploy: delete the feed row via `DELETE /api/feeds?id=phantom-power-music-phantom-power-business-hour`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)