### PR TITLE
fix: sort PI episodes oldest-first so index-based trackOrder isn't reversed

### DIFF
--- a/lib/feed-parsing.ts
+++ b/lib/feed-parsing.ts
@@ -483,8 +483,17 @@ export async function getEpisodesFromAPI(feedId: number): Promise<ParsedEpisode[
       return null;
     }
 
+    // PI returns episodes newest-first; sort oldest-first so callers that
+    // assign trackOrder = index + 1 (when ep.episode is null — PI doesn't
+    // surface <podcast:episode> tags) get chronological album order instead
+    // of a reversed one. Identical-timestamp items stay in PI's tie order;
+    // the corrective for those is an admin reparse (RSS document order).
+    const sortedItems = [...episodesData.items].sort(
+      (a: any, b: any) => (a.datePublished || 0) - (b.datePublished || 0)
+    );
+
     // Convert Podcast Index episodes to our format with v4v data
-    const episodes: ParsedEpisode[] = episodesData.items.map((ep: any) => ({
+    const episodes: ParsedEpisode[] = sortedItems.map((ep: any) => ({
       title: ep.title,
       description: ep.description || '',
       guid: ep.guid,


### PR DESCRIPTION
## Problem
https://stablekraft.app/album/spiritual-waltz-and-magic imported with tracks in reverse order (Magic before Spiritual Waltz).

## Root cause
- Podcast Index `/episodes/byfeedid` returns episodes **newest-first**, and PI does not surface `<podcast:episode>` tags in its `episode` field (the feed uses Podcasting 2.0 `podcast:episode`/`podcast:season`, not `itunes:episode`).
- All PI-based import paths (`publishers/import-albums`, `admin/feeds/import-from-pi`, `importFeedToDatabase` via `parseFeedByGuid`/`parse-feeds`) fall back to `trackOrder = index + 1` when `ep.episode` is null — so albums without PI-visible episode numbers import reversed.

## Fix
Stable-sort PI episodes ascending by `datePublished` inside `getEpisodesFromAPI()` so every caller's index-based fallback yields chronological album order. Verified no caller depends on newest-first order. Identical-timestamp items stay in PI's tie order; the corrective for those is an admin reparse, which uses RSS document order.

The affected album was already fixed in prod via reparse (now ordered by its `podcast:episode` numbers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)