### PR TITLE
feat: reparse newly imported feeds from RSS in nightly workflow (Step 5c)

### DIFF
--- a/.github/workflows/refresh-playlists.yml
+++ b/.github/workflows/refresh-playlists.yml
@@ -182,6 +182,30 @@ jobs:
           IMPORTED=$(echo "$RESPONSE_BODY" | jq -r '.totals.imported // 0' 2>/dev/null || echo "?")
           SKIPPED=$(echo "$RESPONSE_BODY" | jq -r '.totals.skipped // 0' 2>/dev/null || echo "?")
           echo "✅ Publisher album import: ${IMPORTED} imported, ${SKIPPED} skipped"
+
+          # Step 5c: Reparse each newly imported feed from its real RSS.
+          # PI API misses podcast:episode/podcast:season track ordering,
+          # chapters, and VTS — reparse reads the feed XML directly and
+          # fixes all of them. Only runs for feeds created this run, so
+          # fetch volume stays tiny (no Wavlake rate-limit risk).
+          NEW_FEED_IDS=$(echo "$RESPONSE_BODY" | jq -r '.importedFeedIds[]?' 2>/dev/null)
+          if [ -n "$NEW_FEED_IDS" ]; then
+            echo ""
+            echo "📋 Step 5c: Reparsing newly imported feeds from RSS..."
+            while IFS= read -r FEED_ID; do
+              [ -z "$FEED_ID" ] && continue
+              echo "  🔄 Reparsing $FEED_ID..."
+              REPARSE_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "${BASE_URL}/api/admin/feeds/${FEED_ID}/reparse") || REPARSE_CODE=000
+              if [ "$REPARSE_CODE" -eq 200 ]; then
+                echo "  ✓ $FEED_ID reparsed"
+              else
+                echo "  ⚠️ $FEED_ID reparse failed (HTTP $REPARSE_CODE) - non-critical"
+              fi
+              sleep 2
+            done <<< "$NEW_FEED_IDS"
+          else
+            echo "ℹ️ No newly imported feeds to reparse"
+          fi
         else
           echo "⚠️ Publisher album import had issues (HTTP $HTTP_CODE) - non-critical"
         fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ zsp publish --skip-certificate-linking                                          
 - **stablekraft-app** (this repo) - Consumes and displays playlists
 
 ### Daily Workflow (`.github/workflows/refresh-playlists.yml`)
-Runs at 4 AM EST: clears cache → reparses feeds → refreshes playlists → parses publishers → imports missing albums from publisher feeds (Step 5b via PI API). The `PLAYLISTS` array must include ALL playlist IDs — missing ones won't get nightly processing.
+Runs at 4 AM EST: clears cache → reparses feeds → refreshes playlists → parses publishers → imports missing albums from publisher feeds (Step 5b via PI API) → reparses each newly imported feed from its real RSS (Step 5c, driven by `importedFeedIds` in the Step 5b response). Step 5c exists because PI's episodes API doesn't surface `<podcast:episode>`/`<podcast:season>` ordering, chapters, or VTS — only the RSS has them. The `PLAYLISTS` array must include ALL playlist IDs — missing ones won't get nightly processing.
 
 ### Podping Consumer Integration
 External service `msp-podping-service` (repo `ChadFarrow/msp-podping-service`) tails Hive for `pp_music_*` / `pp_podcast_*` podpings. For each ping the consumer (`consumer/src/index.ts:handleIri`) calls `/api/feeds/exists`; if it exists, calls `/api/feeds/refresh-by-url` **regardless of signer**. Only `/api/feeds` (new-feed minting) is gated to signer=`chadf` via `fromMsp` check in the consumer.

--- a/app/api/admin/publishers/import-albums/route.ts
+++ b/app/api/admin/publishers/import-albums/route.ts
@@ -111,6 +111,7 @@ export async function POST(request: NextRequest) {
       title: string;
       piResults: number;
       imported: number;
+      importedFeedIds: string[];
       skipped: number;
       failed: number;
       errors: string[];
@@ -123,6 +124,7 @@ export async function POST(request: NextRequest) {
         title: publisher.title || publisher.id,
         piResults: 0,
         imported: 0,
+        importedFeedIds: [] as string[],
         skipped: 0,
         failed: 0,
         errors: [] as string[],
@@ -347,6 +349,7 @@ export async function POST(request: NextRequest) {
 
             console.log(`   ✅ ${piFeed.title} (${episodes.length} tracks)`);
             result.imported++;
+            result.importedFeedIds.push(feed.id);
 
             await new Promise(r => setTimeout(r, 100));
           } catch (error) {
@@ -387,6 +390,10 @@ export async function POST(request: NextRequest) {
       success: true,
       message: `Processed ${totals.publishers} publishers: ${totals.imported} albums imported`,
       totals,
+      // Flat list of feed IDs created this run — the nightly workflow's
+      // Step 5c reparses each one from its real RSS (PI API misses
+      // podcast:episode track order, chapters, and VTS).
+      importedFeedIds: results.flatMap(r => r.importedFeedIds),
       results
     });
 


### PR DESCRIPTION
## Why
Podcast Index's episodes API doesn't surface `<podcast:episode>`/`<podcast:season>` ordering (verified directly against PI for the Henrik Flyman feed — `episode: null`, `season: 0` despite the tags being in the RSS), and per CLAUDE.md the PI-based initial import can also miss chapters and VTS. Only the real RSS has all of it. This is what let spiritual-waltz-and-magic import with reversed tracks.

## What
- `POST /api/admin/publishers/import-albums` now returns a flat `importedFeedIds` list of feeds it created this run (plus per-publisher lists in `results`).
- `refresh-playlists.yml` gains **Step 5c** inside Step 5b's success branch: loops over `importedFeedIds` and POSTs the existing `/api/admin/feeds/{id}/reparse` endpoint for each, 2s apart. Reparse reads the feed XML directly and corrects track order, chapters, VTS, and V4V.
- CLAUDE.md Daily Workflow section updated.

Fetch volume = newly created feeds per night (usually 0–5), so no Wavlake rate-limit risk. Reparse failures are logged as non-critical, matching the workflow's existing error style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)