### PR TITLE
Fix settings page showing defaults after logout/login

### DIFF
--- a/components/Settings/UserSettings.tsx
+++ b/components/Settings/UserSettings.tsx
@@ -1,16 +1,27 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { SettingsSection, SettingsRow } from './SettingsLayout';
 import { useUserSettings } from '@/hooks/useUserSettings';
 import { useBitcoinConnect } from '@/components/Lightning/BitcoinConnectProvider';
 
 export default function UserSettings() {
-  const { settings, updateSettings } = useUserSettings();
+  const { settings, isLoaded, updateSettings } = useUserSettings();
   const { isConnected: isWalletConnected } = useBitcoinConnect();
   const [boostAmount, setBoostAmount] = useState(settings.defaultBoostAmount?.toString() || '21');
   const [boostName, setBoostName] = useState(settings.defaultBoostName || '');
   const [autoBoostAmount, setAutoBoostAmount] = useState(settings.autoBoostAmount?.toString() || '50');
+
+  // Sync display state once localStorage has been read — useState initial values
+  // may be captured before the provider's load effect finishes.
+  useEffect(() => {
+    if (isLoaded) {
+      setBoostAmount(settings.defaultBoostAmount?.toString() || '21');
+      setBoostName(settings.defaultBoostName || '');
+      setAutoBoostAmount(settings.autoBoostAmount?.toString() || '50');
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isLoaded]);
 
   const handleBoostAmountChange = (value: string) => {
     setBoostAmount(value);

--- a/contexts/UserSettingsContext.tsx
+++ b/contexts/UserSettingsContext.tsx
@@ -23,6 +23,7 @@ export interface UserSettings {
 
 interface UserSettingsContextType {
   settings: UserSettings;
+  isLoaded: boolean;
   updateSettings: (updates: Partial<UserSettings>) => void;
   resetSettings: () => void;
 }
@@ -103,6 +104,7 @@ export function UserSettingsProvider({ children }: { children: ReactNode }) {
 
   const value: UserSettingsContextType = {
     settings,
+    isLoaded,
     updateSettings,
     resetSettings,
   };


### PR DESCRIPTION
The UserSettings component initialized its local form state (boostAmount,
boostName, autoBoostAmount) via useState — which only captures context
values at first mount. Since the UserSettingsProvider's localStorage load
runs in a useEffect (after the initial render), the component could mount
while settings still held defaults, permanently locking the inputs to 21
sats / empty name even though the correct values were in localStorage.

Fix: expose isLoaded from UserSettingsContext and add a one-shot useEffect
in UserSettings that re-syncs local form state as soon as the load
completes. The save path is unchanged — changes still write to context and
localStorage on every keystroke.

https://claude.ai/code/session_01Edo8rvFnJEjvq8ntM9mQpF